### PR TITLE
External references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY:
 build-spec-tests:
-	go run sszgen/*.go --path ./spectests/structs.go
+	go run sszgen/*.go --path ./spectests/structs.go --include ./spectests/external
 
 .PHONY:
 ef-tests:

--- a/spectests/external/bytes.go
+++ b/spectests/external/bytes.go
@@ -1,7 +1,44 @@
 package external
 
+import ssz "github.com/ferranbt/fastssz"
+
 // Signature is a 96 bytes array external reference
 type Signature [96]byte
 
 // Bytes is a dynamic array of bytes
 type Bytes []byte
+
+// DynamicBytes is a dynamic reference
+type DynamicBytes []byte
+
+// SizeSSZ implements the fastssz Marshaler interface
+func (d *DynamicBytes) SizeSSZ() (size int) {
+	return len(*d)
+}
+
+// MarshalSSZTo implements the fastssz Marshaler interface
+func (d *DynamicBytes) MarshalSSZTo(buf []byte) ([]byte, error) {
+	if len(*d) > 256 {
+		return nil, ssz.ErrBytesLength
+	}
+	return append(buf, *d...), nil
+}
+
+// HashTreeRootWith implements the fastssz HashRoot interface
+func (d *DynamicBytes) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+	if len(*d) > 256 {
+		err = ssz.ErrBytesLength
+		return
+	}
+	hh.PutBytes(*d)
+	return
+}
+
+// UnmarshalSSZ implements the fastssz Unmarshaler interface
+func (d *DynamicBytes) UnmarshalSSZ(buf []byte) error {
+	if len(buf) > 256 {
+		return ssz.ErrBytesLength
+	}
+	(*d) = append(*d, buf...)
+	return nil
+}

--- a/spectests/external/bytes.go
+++ b/spectests/external/bytes.go
@@ -1,0 +1,7 @@
+package external
+
+// Signature is a 96 bytes array external reference
+type Signature [96]byte
+
+// Bytes is a dynamic array of bytes
+type Bytes []byte

--- a/spectests/structs.go
+++ b/spectests/structs.go
@@ -1,9 +1,11 @@
 package spectests
 
+import "github.com/ferranbt/fastssz/spectests/external"
+
 type AggregateAndProof struct {
-	Index          uint64       `json:"aggregator_index"`
-	Aggregate      *Attestation `json:"aggregate"`
-	SelectionProof [96]byte     `json:"selection_proof" ssz-size:"96"`
+	Index          uint64             `json:"aggregator_index"`
+	Aggregate      *Attestation       `json:"aggregate"`
+	SelectionProof external.Signature `json:"selection_proof" ssz-size:"96"`
 }
 
 type Checkpoint struct {
@@ -26,10 +28,10 @@ type Attestation struct {
 }
 
 type DepositData struct {
-	Pubkey                [48]byte `json:"pubkey" ssz-size:"48"`
-	WithdrawalCredentials [32]byte `json:"withdrawal_credentials" ssz-size:"32"`
-	Amount                uint64   `json:"amount"`
-	Signature             []byte   `json:"signature" ssz-size:"96"`
+	Pubkey                [48]byte       `json:"pubkey" ssz-size:"48"`
+	WithdrawalCredentials [32]byte       `json:"withdrawal_credentials" ssz-size:"32"`
+	Amount                uint64         `json:"amount"`
+	Signature             external.Bytes `json:"signature" ssz-size:"96"`
 }
 
 type Deposit struct {

--- a/spectests/structs.go
+++ b/spectests/structs.go
@@ -187,5 +187,5 @@ type BeaconBlockHeader struct {
 }
 
 type ErrorResponse struct {
-	Message []byte `ssz-max:"256"`
+	Message external.DynamicBytes `ssz-max:"256"`
 }

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -3439,14 +3439,12 @@ func (e *ErrorResponse) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (0) 'Message'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(e.Message)
+	offset += e.Message.SizeSSZ()
 
 	// Field (0) 'Message'
-	if len(e.Message) > 256 {
-		err = ssz.ErrBytesLength
+	if dst, err = e.Message.MarshalSSZTo(dst); err != nil {
 		return
 	}
-	dst = append(dst, e.Message...)
 
 	return
 }
@@ -3470,10 +3468,9 @@ func (e *ErrorResponse) UnmarshalSSZ(buf []byte) error {
 	// Field (0) 'Message'
 	{
 		buf = tail[o0:]
-		if len(buf) > 256 {
-			return ssz.ErrBytesLength
+		if err = e.Message.UnmarshalSSZ(buf); err != nil {
+			return err
 		}
-		e.Message = append(e.Message, buf...)
 	}
 	return err
 }
@@ -3483,7 +3480,7 @@ func (e *ErrorResponse) SizeSSZ() (size int) {
 	size = 4
 
 	// Field (0) 'Message'
-	size += len(e.Message)
+	size += e.Message.SizeSSZ()
 
 	return
 }
@@ -3498,11 +3495,9 @@ func (e *ErrorResponse) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Message'
-	if len(e.Message) > 256 {
-		err = ssz.ErrBytesLength
+	if err = e.Message.HashTreeRootWith(hh); err != nil {
 		return
 	}
-	hh.PutBytes(e.Message)
 
 	hh.Merkleize(indx)
 	return

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -91,7 +91,7 @@ func (v *Value) hashRoots(isList bool, elem Type) string {
 
 func (v *Value) hashTreeRoot() string {
 	switch v.t {
-	case TypeContainer:
+	case TypeContainer, TypeReference:
 		return v.hashTreeRootContainer(false)
 
 	case TypeBytes:

--- a/sszgen/marshal.go
+++ b/sszgen/marshal.go
@@ -37,7 +37,7 @@ func (e *env) marshal(name string, v *Value) string {
 
 func (v *Value) marshal() string {
 	switch v.t {
-	case TypeContainer:
+	case TypeContainer, TypeReference:
 		return v.marshalContainer(false)
 
 	case TypeBytes:
@@ -140,6 +140,9 @@ func (v *Value) marshalContainer(start bool) string {
 		// validate only for fixed structs
 		check := v.isFixed()
 		if v.isListElem() {
+			check = false
+		}
+		if v.t == TypeReference && v.c {
 			check = false
 		}
 		return execTmpl(tmpl, map[string]interface{}{

--- a/sszgen/size.go
+++ b/sszgen/size.go
@@ -31,16 +31,23 @@ func (e *env) size(name string, v *Value) string {
 
 func (v *Value) sizeContainer(name string, start bool) string {
 	if !start {
-		tmpl := `{{if not .isList}} if ::.{{.name}} == nil {
+		tmpl := `{{if .check}} if ::.{{.name}} == nil {
 			::.{{.name}} = new({{.obj}})
 		}
 		{{end}} {{ .dst }} += ::.{{.name}}.SizeSSZ()`
 
+		check := true
+		if v.isListElem() {
+			check = false
+		}
+		if v.t == TypeReference && v.c {
+			check = false
+		}
 		return execTmpl(tmpl, map[string]interface{}{
-			"name":   v.name,
-			"dst":    name,
-			"obj":    v.objRef(),
-			"isList": v.isListElem(),
+			"name":  v.name,
+			"dst":   name,
+			"obj":   v.objRef(),
+			"check": check,
 		})
 	}
 	out := []string{}
@@ -66,7 +73,7 @@ func (v *Value) size(name string) string {
 	}
 
 	switch v.t {
-	case TypeContainer:
+	case TypeContainer, TypeReference:
 		return v.sizeContainer(name, false)
 
 	case TypeBitList:


### PR DESCRIPTION
This PR adds support for fields in the struct that are references in another package. It supports two forms:
- Fixed types for []byte and [x]byte
- Dynamic types that implement the Marshaler, Unmarshaler and HashRoot interface.