### PR TITLE
Ignore test packages when reading AST.

### DIFF
--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -142,7 +142,9 @@ func parseInput(source string) (map[string]*ast.File, error) {
 			return nil, err
 		}
 		for _, v := range astFiles {
-			files = v.Files
+			if !strings.HasSuffix(v.Name, "_test") {
+				files = v.Files
+			}
 		}
 	} else {
 		// single file


### PR DESCRIPTION
If `sszgen` is run in a directory that contains tests it fails to generate the required files.  This patch ignores any packages ending in `_test` when obtaining the files for which to generate the SSZ functions.