### PR TITLE
Fix import alias of basic types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY:
 build-spec-tests:
-	go run sszgen/*.go --path ./spectests/structs.go --include ./spectests/external
+	go run sszgen/*.go --path ./spectests/structs.go --include ./spectests/external,./spectests/external2
 
 .PHONY:
 get-spec-tests:

--- a/spectests/external/bytes.go
+++ b/spectests/external/bytes.go
@@ -4,9 +4,6 @@ import (
 	ssz "github.com/ferranbt/fastssz"
 )
 
-// EpochAlias is an alias to a uint64 value
-type EpochAlias uint64
-
 // Signature is a 96 bytes array external reference
 type Signature struct {
 	Data [96]byte

--- a/spectests/external2/external.go
+++ b/spectests/external2/external.go
@@ -1,0 +1,4 @@
+package external2
+
+// EpochAlias is an alias to a uint64 value
+type EpochAlias uint64

--- a/spectests/structs.go
+++ b/spectests/structs.go
@@ -1,6 +1,9 @@
 package spectests
 
-import "github.com/ferranbt/fastssz/spectests/external"
+import (
+	"github.com/ferranbt/fastssz/spectests/external"
+	external2Alias "github.com/ferranbt/fastssz/spectests/external2"
+)
 
 type AggregateAndProof struct {
 	Index          uint64             `json:"aggregator_index"`
@@ -9,8 +12,8 @@ type AggregateAndProof struct {
 }
 
 type Checkpoint struct {
-	Epoch external.EpochAlias `json:"epoch"`
-	Root  []byte              `json:"root" ssz-size:"32"`
+	Epoch external2Alias.EpochAlias `json:"epoch"`
+	Root  []byte                    `json:"root" ssz-size:"32"`
 }
 
 type AttestationData struct {

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -4,6 +4,7 @@ package spectests
 import (
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/ferranbt/fastssz/spectests/external"
+	external2Alias "github.com/ferranbt/fastssz/spectests/external2"
 )
 
 // MarshalSSZ ssz marshals the AggregateAndProof object
@@ -146,7 +147,7 @@ func (c *Checkpoint) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Epoch'
-	c.Epoch = external.EpochAlias(ssz.UnmarshallUint64(buf[0:8]))
+	c.Epoch = external2Alias.EpochAlias(ssz.UnmarshallUint64(buf[0:8]))
 
 	// Field (1) 'Root'
 	if cap(c.Root) == 0 {

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -434,6 +434,8 @@ func detectImports(v *Value) []string {
 			ref = i.ref
 		case TypeList, TypeVector:
 			ref = i.e.ref
+		default:
+			ref = i.ref
 		}
 		if ref != "" {
 			refs = append(refs, ref)


### PR DESCRIPTION
There was not importing for basic types only complex (vector, containers, references). The previous PR worked because the uint alias was on the same package as other complex types.