### PR TITLE
Show an error when size for type does not correspond to the tag described in a struct tag

### DIFF
--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -749,7 +749,7 @@ func (e *env) encodeItem(name, tags string) (*Value, error) {
 		case *ast.ArrayType:
 			arrayLength := getObjLen(obj)
 			if arrayLength != e.objs[name].s {
-				return nil, fmt.Errorf("failed to encode %s: Length does not match the one defined in struct's field tag", name)
+				return nil, fmt.Errorf("failed to encode %s: Size in type declaration does not match the size defined a structure's field tag", name)
 			}
 		}
 	}
@@ -869,7 +869,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 			}
 			max, ok := getTagsInt(tags, "ssz-max")
 			if !ok {
-				return nil, fmt.Errorf("[]byte expects either ssz-max or ssz-size")
+				return nil, fmt.Errorf("[]byte expects either ssz-max or ssz-size or an explicit size in type definition")
 			}
 			// dynamic bytes
 			return &Value{t: TypeBytes, m: max}, nil

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -742,6 +742,16 @@ func (e *env) encodeItem(name, tags string) (*Value, error) {
 		v.name = name
 		v.obj = name
 		e.objs[name] = v
+	} else {
+		raw, _ := e.raw[name]
+		expr := raw.typ
+		switch obj := expr.(type) {
+		case *ast.ArrayType:
+			arrayLength := getObjLen(obj)
+			if arrayLength != e.objs[name].s {
+				return nil, fmt.Errorf("failed to encode %s: Length does not match the one defined in struct's field tag", name)
+			}
+		}
 	}
 	return v.copy(), nil
 }

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -743,13 +743,14 @@ func (e *env) encodeItem(name, tags string) (*Value, error) {
 		v.obj = name
 		e.objs[name] = v
 	} else {
-		raw, _ := e.raw[name]
-		expr := raw.typ
-		switch obj := expr.(type) {
-		case *ast.ArrayType:
-			arrayLength := getObjLen(obj)
-			if arrayLength != e.objs[name].s {
-				return nil, fmt.Errorf("failed to encode %s: Size in type declaration does not match the size defined a structure's field tag", name)
+		raw, ok := e.raw[name]
+		if ok {
+			switch obj := raw.typ.(type) {
+			case *ast.ArrayType:
+				arrayLength := getObjLen(obj)
+				if arrayLength != e.objs[name].s {
+					return nil, fmt.Errorf("failed to encode %s: Size in type declaration does not match the size defined a structure's field tag", name)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I was testing the library using this schema https://github.com/s1na/fastssz/blob/8f8e2c18f1c85e157e7b8d22bde491831c5ebc8d/tests/codetrie.go#L15

Some times showed me this error: `[ERR]: failed to encode Hash: []byte expects either ssz-max or ssz-size`, and sometimes worked just fine.

The error occurred when the first element to be processed is `Hash`. When processing the `Metadata` structure first it was correctly finding the size for `Hash` by inspecting the tag and when getting to `Hash` again it detected it already "knew" the size.

In this change, when processing `Hash` after the structure, it will check if the size of the array type definition corresponds to the one specified in the structure's field tag. When processing `Hash` type definition first it will show the same error but also indicating the possibility to fix this problem by just adding a length to the type definition.

