### PR TITLE
Generate multiproof

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -20,18 +20,22 @@ var (
 )
 
 var zeroHashes [65][32]byte
+var zeroHashLevels map[string]int
 var trueBytes, falseBytes []byte
 
 func init() {
 	falseBytes = make([]byte, 32)
 	trueBytes = make([]byte, 32)
 	trueBytes[0] = 1
+	zeroHashLevels = make(map[string]int)
+	zeroHashLevels[string(falseBytes)] = 0
 
 	tmp := [64]byte{}
 	for i := 0; i < 64; i++ {
 		copy(tmp[:32], zeroHashes[i][:])
 		copy(tmp[32:], zeroHashes[i][:])
 		zeroHashes[i+1] = sha256.Sum256(tmp[:])
+		zeroHashLevels[string(zeroHashes[i+1][:])] = i + 1
 	}
 }
 

--- a/proof.go
+++ b/proof.go
@@ -12,15 +12,15 @@ import (
 
 // VerifyProof verifies a single merkle branch. It's more
 // efficient than VerifyMultiproof for proving one leaf.
-func VerifyProof(root []byte, proof [][]byte, leaf []byte, index int) (bool, error) {
-	if len(proof) != getPathLength(index) {
+func VerifyProof(root []byte, proof *Proof) (bool, error) {
+	if len(proof.Hashes) != getPathLength(proof.Index) {
 		return false, errors.New("Invalid proof length")
 	}
 
-	node := leaf[:]
+	node := proof.Leaf[:]
 	tmp := make([]byte, 64)
-	for i, h := range proof {
-		if getPosAtLevel(index, i) {
+	for i, h := range proof.Hashes {
+		if getPosAtLevel(proof.Index, i) {
 			copy(tmp[:32], h[:])
 			copy(tmp[32:], node[:])
 			node = hashFn(tmp)

--- a/tests/codetrie.go
+++ b/tests/codetrie.go
@@ -1,5 +1,12 @@
 package tests
 
+import (
+	"encoding/binary"
+	"errors"
+
+	ssz "github.com/ferranbt/fastssz"
+)
+
 type Hash []byte
 
 type Metadata struct {
@@ -16,4 +23,82 @@ type Chunk struct {
 type CodeTrieSmall struct {
 	Metadata *Metadata
 	Chunks   []*Chunk `ssz-max:"4"`
+}
+
+func (md *Metadata) GetTree() (*ssz.Node, error) {
+	leaves := md.getLeaves()
+	return ssz.TreeFromChunks(leaves)
+}
+
+func (md *Metadata) getLeaves() [][]byte {
+	chunks := make([][]byte, 4)
+	chunks[0] = make([]byte, 32) // Version
+	chunks[0][0] = md.Version
+	chunks[1] = md.CodeHash[:]
+	chunks[2] = make([]byte, 32)
+	binary.LittleEndian.PutUint16(chunks[2][:2], md.CodeLength)
+	chunks[3] = make([]byte, 32)
+	return chunks
+}
+
+func (t *CodeTrieSmall) GetTree() (*ssz.Node, error) {
+	// Metadata tree
+	mdTree, err := t.Metadata.GetTree()
+	if err != nil {
+		return nil, err
+	}
+	chunkMixinTree, err := t.getChunkListTree()
+	if err != nil {
+		return nil, err
+	}
+	// Tree with metadata and chunks subtrees
+	return ssz.NewNodeWithLR(mdTree, chunkMixinTree), nil
+}
+
+func (t *CodeTrieSmall) getChunkListTree() (*ssz.Node, error) {
+	// Construct a tree  for each chunk
+	if len(t.Chunks) > 4 {
+		return nil, errors.New("Number of chunks exceeds capacity")
+	}
+
+	chunkTrees := make([]*ssz.Node, 4)
+	emptyLeaf := ssz.NewNodeWithValue(make([]byte, 32))
+	for i := 0; i < 4; i++ {
+		chunkTrees[i] = emptyLeaf
+		if i < len(t.Chunks) {
+			c := t.Chunks[i]
+			t, err := c.GetTree()
+			if err != nil {
+				return nil, err
+			}
+			chunkTrees[i] = t
+		}
+	}
+
+	// Construct a tree out of all chunk subtrees
+	chunksTree, err := ssz.TreeFromNodes(chunkTrees)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mixin chunks len
+	chunkCountLeafValue := make([]byte, 32)
+	binary.LittleEndian.PutUint64(chunkCountLeafValue[:], uint64(len(t.Chunks)))
+	chunkCountLeaf := ssz.NewNodeWithValue(chunkCountLeafValue)
+
+	chunkMixinTree := ssz.NewNodeWithLR(chunksTree, chunkCountLeaf)
+	return chunkMixinTree, nil
+}
+
+func (c *Chunk) GetTree() (*ssz.Node, error) {
+	leaves := c.getLeaves()
+	return ssz.TreeFromChunks(leaves)
+}
+
+func (c *Chunk) getLeaves() [][]byte {
+	chunks := make([][]byte, 2)
+	chunks[0] = make([]byte, 32)
+	chunks[0][0] = c.FIO
+	chunks[1] = c.Code[:]
+	return chunks
 }

--- a/tests/codetrie.go
+++ b/tests/codetrie.go
@@ -25,6 +25,11 @@ type CodeTrieSmall struct {
 	Chunks   []*Chunk `ssz-max:"4"`
 }
 
+type CodeTrieBig struct {
+	Metadata *Metadata
+	Chunks   []*Chunk `ssz-max:"1024"`
+}
+
 func (md *Metadata) GetTree() (*ssz.Node, error) {
 	leaves := md.getLeaves()
 	return ssz.TreeFromChunks(leaves)
@@ -56,17 +61,21 @@ func (t *CodeTrieSmall) GetTree() (*ssz.Node, error) {
 }
 
 func (t *CodeTrieSmall) getChunkListTree() (*ssz.Node, error) {
+	return getChunkListTree(4, t.Chunks)
+}
+
+func getChunkListTree(size int, chunks []*Chunk) (*ssz.Node, error) {
 	// Construct a tree  for each chunk
-	if len(t.Chunks) > 4 {
+	if len(chunks) > size {
 		return nil, errors.New("Number of chunks exceeds capacity")
 	}
 
-	chunkTrees := make([]*ssz.Node, 4)
+	chunkTrees := make([]*ssz.Node, size)
 	emptyLeaf := ssz.NewNodeWithValue(make([]byte, 32))
-	for i := 0; i < 4; i++ {
+	for i := 0; i < size; i++ {
 		chunkTrees[i] = emptyLeaf
-		if i < len(t.Chunks) {
-			c := t.Chunks[i]
+		if i < len(chunks) {
+			c := chunks[i]
 			t, err := c.GetTree()
 			if err != nil {
 				return nil, err
@@ -83,11 +92,29 @@ func (t *CodeTrieSmall) getChunkListTree() (*ssz.Node, error) {
 
 	// Mixin chunks len
 	chunkCountLeafValue := make([]byte, 32)
-	binary.LittleEndian.PutUint64(chunkCountLeafValue[:], uint64(len(t.Chunks)))
+	binary.LittleEndian.PutUint64(chunkCountLeafValue[:], uint64(len(chunks)))
 	chunkCountLeaf := ssz.NewNodeWithValue(chunkCountLeafValue)
 
 	chunkMixinTree := ssz.NewNodeWithLR(chunksTree, chunkCountLeaf)
 	return chunkMixinTree, nil
+}
+
+func (t *CodeTrieBig) GetTree() (*ssz.Node, error) {
+	// Metadata tree
+	mdTree, err := t.Metadata.GetTree()
+	if err != nil {
+		return nil, err
+	}
+	chunkMixinTree, err := t.getChunkListTree()
+	if err != nil {
+		return nil, err
+	}
+	// Tree with metadata and chunks subtrees
+	return ssz.NewNodeWithLR(mdTree, chunkMixinTree), nil
+}
+
+func (t *CodeTrieBig) getChunkListTree() (*ssz.Node, error) {
+	return getChunkListTree(1024, t.Chunks)
 }
 
 func (c *Chunk) GetTree() (*ssz.Node, error) {

--- a/tests/codetrie_test.go
+++ b/tests/codetrie_test.go
@@ -434,21 +434,6 @@ func BenchmarkHashTreeRootVsNode(b *testing.B) {
 
 	codeTrie := &CodeTrieBig{Metadata: md, Chunks: chunks}
 
-	tree, err := codeTrie.GetTree()
-	if err != nil {
-		b.Errorf("Failed to construct tree for codeTrie: %v\n", err)
-	}
-
-	// First make sure outputs match
-	treeHash := tree.Hash()
-	expectedHash, err := codeTrie.HashTreeRoot()
-	if err != nil {
-		b.Errorf("Failed to hash tree root: %v\n", err)
-	}
-	if !bytes.Equal(treeHash, expectedHash[:]) {
-		b.Errorf("Tree root hashes mismatch\n")
-	}
-
 	b.Run("HashTreeRoot", func(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
@@ -460,6 +445,11 @@ func BenchmarkHashTreeRootVsNode(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
+			tree, err := codeTrie.GetTree()
+			if err != nil {
+				b.Errorf("Failed to construct tree for codeTrie: %v\n", err)
+			}
+
 			tree.Hash()
 		}
 	})

--- a/tests/codetrie_test.go
+++ b/tests/codetrie_test.go
@@ -55,13 +55,13 @@ func TestVerifyMetadataProof(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to decode root: %s\n", c.root)
 		}
-		proof := make([][]byte, len(c.proof))
+		hashes := make([][]byte, len(c.proof))
 		for i, p := range c.proof {
 			b, err := hex.DecodeString(p)
 			if err != nil {
 				t.Errorf("Failed to decode proof element: %s\n", p)
 			}
-			proof[i] = b
+			hashes[i] = b
 		}
 		leaf, err := hex.DecodeString(c.leaf)
 		if err != nil {
@@ -69,7 +69,8 @@ func TestVerifyMetadataProof(t *testing.T) {
 		}
 
 		// Verify proof
-		ok, err := ssz.VerifyProof(root, proof, leaf, c.index)
+		proof := &ssz.Proof{Hashes: hashes, Leaf: leaf, Index: c.index}
+		ok, err := ssz.VerifyProof(root, proof)
 		if err != nil {
 			t.Errorf("Failed to verify proof: %v\n", err)
 		}
@@ -118,13 +119,13 @@ func TestVerifyCodeTrieProof(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to decode root: %s\n", c.root)
 		}
-		proof := make([][]byte, len(c.proof))
+		hashes := make([][]byte, len(c.proof))
 		for i, p := range c.proof {
 			b, err := hex.DecodeString(p)
 			if err != nil {
 				t.Errorf("Failed to decode proof element: %s\n", p)
 			}
-			proof[i] = b
+			hashes[i] = b
 		}
 		leaf, err := hex.DecodeString(c.leaf)
 		if err != nil {
@@ -132,7 +133,8 @@ func TestVerifyCodeTrieProof(t *testing.T) {
 		}
 
 		// Verify proof
-		ok, err := ssz.VerifyProof(root, proof, leaf, c.index)
+		proof := &ssz.Proof{Hashes: hashes, Leaf: leaf, Index: c.index}
+		ok, err := ssz.VerifyProof(root, proof)
 		if err != nil {
 			t.Errorf("Failed to verify proof: %v\n", err)
 		}
@@ -311,11 +313,17 @@ func TestProveSmallCodeTrie(t *testing.T) {
 		t.Errorf("Failed to generate proof for codeTrie: %v\n", err)
 	}
 
-	if len(proof) != len(expectedProof) {
-		t.Errorf("Generated proof has invalid length")
+	if proof.Index != 49 {
+		t.Errorf("Proof has invalid index\n")
+	}
+	if !bytes.Equal(proof.Leaf, codePadded) {
+		t.Errorf("Proof has invalid leaf\n")
+	}
+	if len(proof.Hashes) != len(expectedProof) {
+		t.Errorf("Generated proof has invalid length\n")
 	}
 
-	for i, p := range proof {
+	for i, p := range proof.Hashes {
 		if !bytes.Equal(p, expectedProof[i]) {
 			t.Errorf("Proof element mismatch. Expected %s, got %s\n", hex.EncodeToString(expectedProof[i]), hex.EncodeToString(p))
 		}

--- a/tests/codetrie_test.go
+++ b/tests/codetrie_test.go
@@ -330,6 +330,53 @@ func TestProveSmallCodeTrie(t *testing.T) {
 	}
 }
 
+func TestProveMultiSmallCodeTrie(t *testing.T) {
+	expectedProofHex := []string{
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		"f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		"0100000000000000000000000000000000000000000000000000000000000000",
+		"f58f76419d9235451a8290a88ba380d852350a1843f8f26b8257a421633042b4",
+	}
+	expectedProof, err := parseStringSlice(expectedProofHex)
+	if err != nil {
+		t.Errorf("Failed to decode expected proof: %v\n", err)
+	}
+
+	code := []byte{0x60, 0x01}
+	codeHash := sha256.Sum256(code)
+
+	codePadded := make([]byte, 32)
+	copy(codePadded[:2], code[:])
+
+	md := &Metadata{Version: 1, CodeLength: uint16(len(code)), CodeHash: codeHash[:]}
+	chunks := []*Chunk{
+		{FIO: 0, Code: codePadded[:]},
+	}
+	codeTrie := &CodeTrieSmall{Metadata: md, Chunks: chunks}
+
+	tree, err := codeTrie.GetTree()
+	if err != nil {
+		t.Errorf("Failed to construct tree for codeTrie: %v\n", err)
+	}
+
+	proof, err := tree.ProveMulti([]int{10, 49})
+	if err != nil {
+		t.Errorf("Failed to generate proof for codeTrie: %v\n", err)
+	}
+
+	if len(proof.Hashes) != len(expectedProof) {
+		t.Errorf("Generated proof has invalid length\n")
+	}
+
+	for i, p := range proof.Hashes {
+		if !bytes.Equal(p, expectedProof[i]) {
+			t.Errorf("Proof element mismatch. Expected %s, got %s\n", hex.EncodeToString(expectedProof[i]), hex.EncodeToString(p))
+		}
+	}
+}
+
 func parseStringSlice(slice []string) ([][]byte, error) {
 	res := make([][]byte, len(slice))
 	for i, s := range slice {

--- a/tree.go
+++ b/tree.go
@@ -71,6 +71,29 @@ func hashNode(n *Node) []byte {
 	return hashFn(append(hashNode(n.left), hashNode(n.right)...))
 }
 
+func (n *Node) Prove(index int) ([][]byte, error) {
+	pathLen := getPathLength(index)
+	proof := make([][]byte, 0, pathLen)
+
+	cur := n
+	for i := pathLen - 1; i >= 0; i-- {
+		var siblingHash []byte
+		if isRight := getPosAtLevel(index, i); isRight {
+			siblingHash = hashNode(cur.left)
+			cur = cur.right
+		} else {
+			siblingHash = hashNode(cur.right)
+			cur = cur.left
+		}
+		proof = append([][]byte{siblingHash}, proof...)
+		if cur == nil {
+			return nil, errors.New("Node not found in tree")
+		}
+	}
+
+	return proof, nil
+}
+
 func isPowerOfTwo(n int) bool {
 	return (n & (n - 1)) == 0
 }

--- a/tree.go
+++ b/tree.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 )
 
+// Node represents a node in the tree
+// backing of a SSZ object.
 type Node struct {
 	left  *Node
 	right *Node
@@ -11,12 +13,36 @@ type Node struct {
 	value []byte
 }
 
-func NewTree() *Node {
-	return &Node{left: nil, right: nil, value: nil}
+// NewNodeWithValue initializes a leaf node.
+func NewNodeWithValue(value []byte) *Node {
+	return &Node{left: nil, right: nil, value: value}
 }
 
+// NewNodeWithLR initializes a branch node.
+func NewNodeWithLR(left, right *Node) *Node {
+	return &Node{left: left, right: right, value: nil}
+}
+
+// TreeFromChunks constructs a tree from leaf values.
+// The number of leaves should be a power of 2.
 func TreeFromChunks(chunks [][]byte) (*Node, error) {
 	numLeaves := len(chunks)
+	if !isPowerOfTwo(numLeaves) {
+		return nil, errors.New("Number of leaves should be a power of 2")
+	}
+
+	leaves := make([]*Node, numLeaves)
+	for i, c := range chunks {
+		leaves[i] = &Node{left: nil, right: nil, value: c}
+	}
+	return TreeFromNodes(leaves)
+}
+
+// TreeFromNodes constructs a tree from leaf nodes.
+// This is useful for merging subtrees.
+// The number of leaves should be a power of 2.
+func TreeFromNodes(leaves []*Node) (*Node, error) {
+	numLeaves := len(leaves)
 	if !isPowerOfTwo(numLeaves) {
 		return nil, errors.New("Number of leaves should be a power of 2")
 	}
@@ -26,8 +52,7 @@ func TreeFromChunks(chunks [][]byte) (*Node, error) {
 	for i := numNodes; i > 0; i-- {
 		// Is a leaf
 		if i > numNodes-numLeaves {
-			val := chunks[i-numLeaves]
-			nodes[i-1] = &Node{left: nil, right: nil, value: val}
+			nodes[i-1] = leaves[i-numLeaves]
 		} else {
 			// Is a branch node
 			nodes[i-1] = &Node{left: nodes[(i*2)-1], right: nodes[(i*2+1)-1], value: nil}
@@ -37,6 +62,7 @@ func TreeFromChunks(chunks [][]byte) (*Node, error) {
 	return nodes[0], nil
 }
 
+// Get fetches a node with the given general index.
 func (n *Node) Get(index int) (*Node, error) {
 	pathLen := getPathLength(index)
 	cur := n
@@ -54,6 +80,8 @@ func (n *Node) Get(index int) (*Node, error) {
 	return cur, nil
 }
 
+// Hash returns the hash of the subtree with the given Node as its root.
+// If root has no children, it returns root's value (not its hash).
 func (n *Node) Hash() []byte {
 	// TODO: handle special cases: empty root, one non-empty node
 	return hashNode(n)
@@ -71,6 +99,8 @@ func hashNode(n *Node) []byte {
 	return hashFn(append(hashNode(n.left), hashNode(n.right)...))
 }
 
+// Prove returns a list of sibling values and hashes needed
+// to compute the root hash for a given general index.
 func (n *Node) Prove(index int) ([][]byte, error) {
 	pathLen := getPathLength(index)
 	proof := make([][]byte, 0, pathLen)

--- a/tree.go
+++ b/tree.go
@@ -1,0 +1,55 @@
+package ssz
+
+import (
+	"errors"
+)
+
+type Node struct {
+	left  *Node
+	right *Node
+
+	value []byte
+}
+
+func NewTree() *Node {
+	return &Node{left: nil, right: nil, value: nil}
+}
+
+func TreeFromChunks(chunks [][]byte) *Node {
+	numLeaves := int(nextPowerOfTwo(uint64(len(chunks))))
+	numEmpty := numLeaves - len(chunks)
+	numNodes := numLeaves*2 - 1
+
+	nodes := make([]*Node, numNodes)
+	for i := numNodes; i > 0; i-- {
+		// It's a leaf
+		if i > numNodes-numLeaves {
+			val := []byte(nil)
+			if i <= numNodes-numEmpty {
+				val = chunks[i-numLeaves]
+			}
+			nodes[i-1] = &Node{left: nil, right: nil, value: val}
+		} else {
+			nodes[i-1] = &Node{left: nodes[(i*2)-1], right: nodes[(i*2+1)-1], value: nil}
+		}
+	}
+
+	return nodes[0]
+}
+
+func (n *Node) Get(index int) (*Node, error) {
+	pathLen := getPathLength(index)
+	cur := n
+	for i := pathLen - 1; i >= 0; i-- {
+		if isRight := getPosAtLevel(index, i); isRight {
+			cur = cur.right
+		} else {
+			cur = cur.left
+		}
+		if cur == nil {
+			return nil, errors.New("Node not found in tree")
+		}
+	}
+
+	return cur, nil
+}

--- a/tree.go
+++ b/tree.go
@@ -15,26 +15,26 @@ func NewTree() *Node {
 	return &Node{left: nil, right: nil, value: nil}
 }
 
-func TreeFromChunks(chunks [][]byte) *Node {
-	numLeaves := int(nextPowerOfTwo(uint64(len(chunks))))
-	numEmpty := numLeaves - len(chunks)
-	numNodes := numLeaves*2 - 1
+func TreeFromChunks(chunks [][]byte) (*Node, error) {
+	numLeaves := len(chunks)
+	if !isPowerOfTwo(numLeaves) {
+		return nil, errors.New("Number of leaves should be a power of 2")
+	}
 
+	numNodes := numLeaves*2 - 1
 	nodes := make([]*Node, numNodes)
 	for i := numNodes; i > 0; i-- {
-		// It's a leaf
+		// Is a leaf
 		if i > numNodes-numLeaves {
-			val := []byte(nil)
-			if i <= numNodes-numEmpty {
-				val = chunks[i-numLeaves]
-			}
+			val := chunks[i-numLeaves]
 			nodes[i-1] = &Node{left: nil, right: nil, value: val}
 		} else {
+			// Is a branch node
 			nodes[i-1] = &Node{left: nodes[(i*2)-1], right: nodes[(i*2+1)-1], value: nil}
 		}
 	}
 
-	return nodes[0]
+	return nodes[0], nil
 }
 
 func (n *Node) Get(index int) (*Node, error) {
@@ -52,4 +52,25 @@ func (n *Node) Get(index int) (*Node, error) {
 	}
 
 	return cur, nil
+}
+
+func (n *Node) Hash() []byte {
+	// TODO: handle special cases: empty root, one non-empty node
+	return hashNode(n)
+}
+
+func hashNode(n *Node) []byte {
+	// Leaf
+	if n.left == nil && n.right == nil {
+		return n.value
+	}
+	// Only one child
+	if n.left == nil || n.right == nil {
+		panic("Tree incomplete")
+	}
+	return hashFn(append(hashNode(n.left), hashNode(n.right)...))
+}
+
+func isPowerOfTwo(n int) bool {
+	return (n & (n - 1)) == 0
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -53,3 +53,39 @@ func TestHashTree(t *testing.T) {
 		t.Errorf("Computed hash is incorrect. Expected %s, got %s\n", expectedRootHex, hex.EncodeToString(h))
 	}
 }
+
+func TestProve(t *testing.T) {
+	expectedProofHex := []string{
+		"0000",
+		"5db57a86b859d1c286b5f1f585048bf8f6b5e626573a8dc728ed5080f6f43e2c",
+	}
+	chunks := [][]byte{
+		{0x01, 0x01},
+		{0x02, 0x02},
+		{0x03, 0x03},
+		{0x00, 0x00},
+	}
+
+	r, err := TreeFromChunks(chunks)
+	if err != nil {
+		t.Errorf("Failed to construct tree: %v\n", err)
+	}
+
+	p, err := r.Prove(6)
+	if err != nil {
+		t.Errorf("Failed to generate proof: %v\n", err)
+	}
+
+	if len(p) != len(expectedProofHex) {
+		t.Errorf("Proof has invalid length. Expected %d, got %d\n", len(expectedProofHex), len(p))
+	}
+	for i, n := range p {
+		e, err := hex.DecodeString(expectedProofHex[i])
+		if err != nil {
+			t.Errorf("Failed to decode hex string: %v\n", err)
+		}
+		if !bytes.Equal(e, n) {
+			t.Errorf("Invalid proof item. Expected %s, got %s\n", expectedProofHex[i], hex.EncodeToString(n))
+		}
+	}
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -2,6 +2,7 @@ package ssz
 
 import (
 	"bytes"
+	"encoding/hex"
 	"testing"
 )
 
@@ -10,22 +11,45 @@ func TestTreeFromChunks(t *testing.T) {
 		{0x01, 0x01},
 		{0x02, 0x02},
 		{0x03, 0x03},
+		{0x00, 0x00},
 	}
 
-	r := TreeFromChunks(chunks)
+	r, err := TreeFromChunks(chunks)
+	if err != nil {
+		t.Errorf("Failed to construct tree: %v\n", err)
+	}
 	for i := 4; i < 8; i++ {
 		l, err := r.Get(i)
 		if err != nil {
 			t.Errorf("Failed getting leaf: %v\n", err)
 		}
-		if i > 6 {
-			if l.value != nil {
-				t.Errorf("Incorrect leaf at index %d. Leaf should be empty\n", i)
-			}
-		} else {
-			if !bytes.Equal(l.value, chunks[i-4]) {
-				t.Errorf("Incorrect leaf at index %d\n", i)
-			}
+		if !bytes.Equal(l.value, chunks[i-4]) {
+			t.Errorf("Incorrect leaf at index %d\n", i)
 		}
+	}
+}
+
+func TestHashTree(t *testing.T) {
+	expectedRootHex := "6621edd5d039d27d1ced186d57691a04903ac79b389187c2d453b5d3cd65180e"
+	expectedRoot, err := hex.DecodeString(expectedRootHex)
+	if err != nil {
+		t.Errorf("Failed to decode hex string\n")
+	}
+
+	chunks := [][]byte{
+		{0x01, 0x01},
+		{0x02, 0x02},
+		{0x03, 0x03},
+		{0x00, 0x00},
+	}
+
+	r, err := TreeFromChunks(chunks)
+	if err != nil {
+		t.Errorf("Failed to construct tree: %v\n", err)
+	}
+
+	h := r.Hash()
+	if !bytes.Equal(h, expectedRoot) {
+		t.Errorf("Computed hash is incorrect. Expected %s, got %s\n", expectedRootHex, hex.EncodeToString(h))
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -76,10 +76,17 @@ func TestProve(t *testing.T) {
 		t.Errorf("Failed to generate proof: %v\n", err)
 	}
 
-	if len(p) != len(expectedProofHex) {
-		t.Errorf("Proof has invalid length. Expected %d, got %d\n", len(expectedProofHex), len(p))
+	if p.Index != 6 {
+		t.Errorf("Proof has invalid index. Expected %d, got %d\n", 6, p.Index)
 	}
-	for i, n := range p {
+	if !bytes.Equal(p.Leaf, chunks[2]) {
+		t.Errorf("Proof has invalid leaf. Expected %v, got %v\n", chunks[2], p.Leaf)
+	}
+	if len(p.Hashes) != len(expectedProofHex) {
+		t.Errorf("Proof has invalid length. Expected %d, got %d\n", len(expectedProofHex), len(p.Hashes))
+	}
+
+	for i, n := range p.Hashes {
 		e, err := hex.DecodeString(expectedProofHex[i])
 		if err != nil {
 			t.Errorf("Failed to decode hex string: %v\n", err)

--- a/tree_test.go
+++ b/tree_test.go
@@ -1,0 +1,31 @@
+package ssz
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTreeFromChunks(t *testing.T) {
+	chunks := [][]byte{
+		{0x01, 0x01},
+		{0x02, 0x02},
+		{0x03, 0x03},
+	}
+
+	r := TreeFromChunks(chunks)
+	for i := 4; i < 8; i++ {
+		l, err := r.Get(i)
+		if err != nil {
+			t.Errorf("Failed getting leaf: %v\n", err)
+		}
+		if i > 6 {
+			if l.value != nil {
+				t.Errorf("Incorrect leaf at index %d. Leaf should be empty\n", i)
+			}
+		} else {
+			if !bytes.Equal(l.value, chunks[i-4]) {
+				t.Errorf("Incorrect leaf at index %d\n", i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds initial support for multiproof generation. The implementation is inefficient, but we can iterate on that.

It was easier to generate a proof given a tree-backing of the SSZ structure. So the file `tree.go` has generic methods for creating a tree (and getting a leaf in a tree). Apart from these generic ones we need methods generated for each SSZ type to get its tree backing. I have examples of those in `tests/codetrie.go`.

Oh and we can later on merge the file `proof.go` into `tree.go`. I didn't do it in this PR because the diff is already large (sorry about that).