### PR TITLE
Remove duplicate leaves from proof

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -132,8 +132,10 @@ func getRequiredIndices(leafIndices []int) []int {
 	// Set of hashes that will be computed
 	// on the path from leaf to root.
 	computed := make(map[int]struct{})
+	leaves := make(map[int]struct{})
 
 	for _, leaf := range leafIndices {
+		leaves[leaf] = exists
 		cur := leaf
 		for cur > 1 {
 			sibling := getSibling(cur)
@@ -147,7 +149,9 @@ func getRequiredIndices(leafIndices []int) []int {
 	requiredList := make([]int, 0, len(required))
 	// Remove computed indices from required ones
 	for r := range required {
-		if _, ok := computed[r]; !ok {
+		_, isComputed := computed[r]
+		_, isLeaf := leaves[r]
+		if !isComputed && !isLeaf {
 			requiredList = append(requiredList, r)
 		}
 	}

--- a/tests/codetrie_test.go
+++ b/tests/codetrie_test.go
@@ -330,6 +330,15 @@ func TestProveSmallCodeTrie(t *testing.T) {
 			t.Errorf("Proof element mismatch. Expected %s, got %s\n", hex.EncodeToString(expectedProof[i]), hex.EncodeToString(p))
 		}
 	}
+
+	root := tree.Hash()
+	ok, err := ssz.VerifyProof(root, proof)
+	if err != nil {
+		t.Error(err)
+	}
+	if !ok {
+		t.Errorf("Could not verify generated proof")
+	}
 }
 
 func TestProveMultiSmallCodeTrie(t *testing.T) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -96,3 +96,40 @@ func TestProve(t *testing.T) {
 		}
 	}
 }
+
+func TestProveMulti(t *testing.T) {
+	chunks := [][]byte{
+		{0x01, 0x01},
+		{0x02, 0x02},
+		{0x03, 0x03},
+		{0x04, 0x04},
+	}
+
+	r, err := TreeFromChunks(chunks)
+	if err != nil {
+		t.Errorf("Failed to construct tree: %v\n", err)
+	}
+
+	p, err := r.ProveMulti([]int{6, 7})
+	if err != nil {
+		t.Errorf("Failed to generate proof: %v\n", err)
+	}
+
+	if len(p.Hashes) != 1 {
+		t.Errorf("Incorrect number of hashes in proof. Expected 1, got %d\n", len(p.Hashes))
+	}
+}
+
+func TestGetRequiredIndices(t *testing.T) {
+	indices := []int{10, 48, 49}
+	expected := []int{25, 13, 11, 7, 4}
+	req := getRequiredIndices(indices)
+	if len(expected) != len(req) {
+		t.Fatalf("Required indices has wrong length. Expected %d, got %d\n", len(expected), len(req))
+	}
+	for i, r := range req {
+		if r != expected[i] {
+			t.Errorf("Invalid required index. Expected %d, got %d\n", expected[i], r)
+		}
+	}
+}


### PR DESCRIPTION
There was an inefficiency in the proof when two (or more) sibling leaves were part of the proof. In that case both the `Hashes` section and the `Leaves` section of the proof contained all siblings.