### PR TITLE
Add Dynamic List of Byte Lists Support

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -271,15 +271,6 @@ func (h *Hasher) Merkleize(indx int) {
 	h.buf = append(h.buf[:indx], input...)
 }
 
-// Merkleize is used to merkleize the last group of the hasher with a limit.
-func (h *Hasher) MerkleizeWithLimit(indx int, limit uint64) {
-	input := h.buf[indx:]
-
-	// merkleize the input
-	input = h.merkleizeImpl(input[:0], input, limit)
-	h.buf = append(h.buf[:indx], input...)
-}
-
 // MerkleizeWithMixin is used to merkleize the last group of the hasher
 func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 	input := h.buf[indx:]

--- a/hasher.go
+++ b/hasher.go
@@ -248,6 +248,20 @@ func (h *Hasher) PutBytes(b []byte) {
 	h.Merkleize(indx)
 }
 
+// PutBytes append bytes but does not merkleize at the end
+func (h *Hasher) PutBytesNoMerkleize(b []byte) {
+	if len(b) <= 32 {
+		h.appendBytes32(b)
+		return
+	}
+
+	// if the bytes are longer than 32 we have to
+	// merkleize the content
+	indx := h.Index()
+	h.appendBytes32(b)
+	h.Merkleize(indx)
+}
+
 // Index marks the current buffer index
 func (h *Hasher) Index() int {
 	return len(h.buf)

--- a/hasher.go
+++ b/hasher.go
@@ -262,6 +262,15 @@ func (h *Hasher) Merkleize(indx int) {
 	h.buf = append(h.buf[:indx], input...)
 }
 
+// Merkleize is used to merkleize the last group of the hasher with a limit.
+func (h *Hasher) MerkleizeWithLimit(indx int, limit uint64) {
+	input := h.buf[indx:]
+
+	// merkleize the input
+	input = h.merkleizeImpl(input[:0], input, limit)
+	h.buf = append(h.buf[:indx], input...)
+}
+
 // MerkleizeWithMixin is used to merkleize the last group of the hasher
 func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 	input := h.buf[indx:]

--- a/hasher.go
+++ b/hasher.go
@@ -254,12 +254,7 @@ func (h *Hasher) PutBytesNoMerkleize(b []byte) {
 		h.appendBytes32(b)
 		return
 	}
-
-	// if the bytes are longer than 32 we have to
-	// merkleize the content
-	indx := h.Index()
 	h.appendBytes32(b)
-	h.Merkleize(indx)
 }
 
 // Index marks the current buffer index

--- a/spectests/structs.go
+++ b/spectests/structs.go
@@ -5,6 +5,10 @@ import (
 	external2Alias "github.com/ferranbt/fastssz/spectests/external2"
 )
 
+type ETHMergeTransactions struct {
+	OpaqueList [][]byte `json:"opaque_list" ssz-size:"?,?" ssz-max:"2048,2048"`
+}
+
 type AggregateAndProof struct {
 	Index          uint64             `json:"aggregator_index"`
 	Aggregate      *Attestation       `json:"aggregate"`

--- a/spectests/structs.go
+++ b/spectests/structs.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ETHMergeTransactions struct {
-	OpaqueList [][]byte `json:"opaque_list" ssz-size:"?,?" ssz-max:"2048,2048"`
+	OpaqueList [][]byte `json:"opaque_list" ssz-size:"?,?" ssz-max:"16384,1048576"`
 }
 
 type AggregateAndProof struct {

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -120,8 +120,9 @@ func (e *ETHMergeTransactions) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		for i := uint64(0); i < num; i++ {
 			txSubIndx := hh.Index()
-			hh.PutBytes(e.OpaqueList[i])
-			hh.MerkleizeWithMixin(txSubIndx, uint64(len(e.OpaqueList[i])), 1048576)
+			hh.PutBytesNoMerkleize(e.OpaqueList[i])
+			maxLength := uint64((1048576 + 31) / 32)
+			hh.MerkleizeWithMixin(txSubIndx, uint64(len(e.OpaqueList[i])), maxLength)
 		}
 		hh.MerkleizeWithMixin(subIndx, num, 16384)
 	}

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -7,6 +7,127 @@ import (
 	external2Alias "github.com/ferranbt/fastssz/spectests/external2"
 )
 
+// MarshalSSZ ssz marshals the ETHMergeTransactions object
+func (e *ETHMergeTransactions) MarshalSSZ() ([]byte, error) {
+	return ssz.MarshalSSZ(e)
+}
+
+// MarshalSSZTo ssz marshals the ETHMergeTransactions object to a target array
+func (e *ETHMergeTransactions) MarshalSSZTo(buf []byte) (dst []byte, err error) {
+	dst = buf
+	offset := int(4)
+
+	// Offset (0) 'OpaqueList'
+	dst = ssz.WriteOffset(dst, offset)
+	for ii := 0; ii < len(e.OpaqueList); ii++ {
+		offset += 4
+		offset += len(e.OpaqueList[ii])
+	}
+
+	// Field (0) 'OpaqueList'
+	if len(e.OpaqueList) > 2048 {
+		err = ssz.ErrListTooBig
+		return
+	}
+	{
+		offset = 4 * len(e.OpaqueList)
+		for ii := 0; ii < len(e.OpaqueList); ii++ {
+			dst = ssz.WriteOffset(dst, offset)
+			offset += len(e.OpaqueList[ii])
+		}
+	}
+	for ii := 0; ii < len(e.OpaqueList); ii++ {
+		if len(e.OpaqueList[ii]) > 2048 {
+			err = ssz.ErrBytesLength
+			return
+		}
+		dst = append(dst, e.OpaqueList[ii]...)
+	}
+
+	return
+}
+
+// UnmarshalSSZ ssz unmarshals the ETHMergeTransactions object
+func (e *ETHMergeTransactions) UnmarshalSSZ(buf []byte) error {
+	var err error
+	size := uint64(len(buf))
+	if size < 4 {
+		return ssz.ErrSize
+	}
+
+	tail := buf
+	var o0 uint64
+
+	// Offset (0) 'OpaqueList'
+	if o0 = ssz.ReadOffset(buf[0:4]); o0 > size {
+		return ssz.ErrOffset
+	}
+
+	// Field (0) 'OpaqueList'
+	{
+		buf = tail[o0:]
+		num, err := ssz.DecodeDynamicLength(buf, 2048)
+		if err != nil {
+			return err
+		}
+		e.OpaqueList = make([][]byte, num)
+		err = ssz.UnmarshalDynamic(buf, num, func(indx int, buf []byte) (err error) {
+			if len(buf) > 2048 {
+				return ssz.ErrBytesLength
+			}
+			if cap(e.OpaqueList[indx]) == 0 {
+				e.OpaqueList[indx] = make([]byte, 0, len(buf))
+			}
+			e.OpaqueList[indx] = append(e.OpaqueList[indx], buf...)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the ETHMergeTransactions object
+func (e *ETHMergeTransactions) SizeSSZ() (size int) {
+	size = 4
+
+	// Field (0) 'OpaqueList'
+	for ii := 0; ii < len(e.OpaqueList); ii++ {
+		size += 4
+		size += len(e.OpaqueList[ii])
+	}
+
+	return
+}
+
+// HashTreeRoot ssz hashes the ETHMergeTransactions object
+func (e *ETHMergeTransactions) HashTreeRoot() ([32]byte, error) {
+	return ssz.HashWithDefaultHasher(e)
+}
+
+// HashTreeRootWith ssz hashes the ETHMergeTransactions object with a hasher
+func (e *ETHMergeTransactions) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+	indx := hh.Index()
+
+	// Field (0) 'OpaqueList'
+	{
+		subIndx := hh.Index()
+		num := uint64(len(e.OpaqueList))
+		if num > 0 {
+			err = ssz.ErrIncorrectListSize
+			return
+		}
+		for i := uint64(0); i < num; i++ {
+			hh.PutBytes(e.OpaqueList[i])
+		}
+		hh.MerkleizeWithMixin(subIndx, num, 0)
+	}
+
+	hh.Merkleize(indx)
+	return
+}
+
 // MarshalSSZ ssz marshals the AggregateAndProof object
 func (a *AggregateAndProof) MarshalSSZ() ([]byte, error) {
 	return ssz.MarshalSSZ(a)

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -121,7 +121,7 @@ func (e *ETHMergeTransactions) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		for i := uint64(0); i < num; i++ {
 			txSubIndx := hh.Index()
 			hh.PutBytes(e.OpaqueList[i])
-			hh.MerkleizeWithMixin(txSubIndx, len(e.OpaqueList[i]), 1048576)
+			hh.MerkleizeWithMixin(txSubIndx, uint64(len(e.OpaqueList[i])), 1048576)
 		}
 		hh.MerkleizeWithMixin(subIndx, num, 16384)
 	}

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -119,8 +119,9 @@ func (e *ETHMergeTransactions) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 			return
 		}
 		for i := uint64(0); i < num; i++ {
+			txSubIndx := hh.Index()
 			hh.PutBytes(e.OpaqueList[i])
-			hh.MerkleizeWithMixin(subIndx, num, 1048576)
+			hh.MerkleizeWithMixin(txSubIndx, len(e.OpaqueList[i]), 1048576)
 		}
 		hh.MerkleizeWithMixin(subIndx, num, 16384)
 	}

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -154,12 +154,14 @@ func (v *Value) hashTreeRoot() string {
 					}
 					for i := uint64(0); i < num; i++ {
 						hh.PutBytes(::.{{.name}}[i])
+						hh.MerkleizeWithMixin(subIndx, num, {{.numInner}})
 					}
 					hh.MerkleizeWithMixin(subIndx, num, {{.num}})
 				}`
 				return execTmpl(tmpl, map[string]interface{}{
-					"name": v.name,
-					"num":  v.m,
+					"name":     v.name,
+					"num":      v.m,
+					"numInner": v.e.m,
 				})
 			}
 		}

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -153,8 +153,9 @@ func (v *Value) hashTreeRoot() string {
 						return
 					}
 					for i := uint64(0); i < num; i++ {
+						txSubIndx := hh.Index()
 						hh.PutBytes(::.{{.name}}[i])
-						hh.MerkleizeWithMixin(subIndx, num, {{.numInner}})
+						hh.MerkleizeWithMixin(txSubIndx, num, {{.numInner}})
 					}
 					hh.MerkleizeWithMixin(subIndx, num, {{.num}})
 				}`

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -155,7 +155,7 @@ func (v *Value) hashTreeRoot() string {
 					for i := uint64(0); i < num; i++ {
 						txSubIndx := hh.Index()
 						hh.PutBytes(::.{{.name}}[i])
-						hh.MerkleizeWithMixin(txSubIndx, len(::.{{.name}}[i]), {{.numInner}})
+						hh.MerkleizeWithMixin(txSubIndx, uint64(len(::.{{.name}}[i])), {{.numInner}})
 					}
 					hh.MerkleizeWithMixin(subIndx, num, {{.num}})
 				}`

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -154,8 +154,9 @@ func (v *Value) hashTreeRoot() string {
 					}
 					for i := uint64(0); i < num; i++ {
 						txSubIndx := hh.Index()
-						hh.PutBytes(::.{{.name}}[i])
-						hh.MerkleizeWithMixin(txSubIndx, uint64(len(::.{{.name}}[i])), {{.numInner}})
+						hh.PutBytesNoMerkleize(::.{{.name}}[i])
+						maxLength := uint64(({{.numInner}} + 31) / 32)
+						hh.MerkleizeWithMixin(txSubIndx, uint64(len(::.{{.name}}[i])), maxLength)
 					}
 					hh.MerkleizeWithMixin(subIndx, num, {{.num}})
 				}`

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -155,7 +155,7 @@ func (v *Value) hashTreeRoot() string {
 					for i := uint64(0); i < num; i++ {
 						txSubIndx := hh.Index()
 						hh.PutBytes(::.{{.name}}[i])
-						hh.MerkleizeWithMixin(txSubIndx, num, {{.numInner}})
+						hh.MerkleizeWithMixin(txSubIndx, len(::.{{.name}}[i]), {{.numInner}})
 					}
 					hh.MerkleizeWithMixin(subIndx, num, {{.num}})
 				}`

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -143,6 +143,25 @@ func (v *Value) hashTreeRoot() string {
 				// return hashBasicSlice(v)
 				return v.hashRoots(true, v.e.t)
 			}
+		} else {
+			if v.e.t == TypeBytes {
+				tmpl := `{
+					subIndx := hh.Index()
+					num := uint64(len(::.{{.name}}))
+					if num > {{.num}} {
+						err = ssz.ErrIncorrectListSize
+						return
+					}
+					for i := uint64(0); i < num; i++ {
+						hh.PutBytes(::.{{.name}}[i])
+					}
+					hh.MerkleizeWithMixin(subIndx, num, {{.num}})
+				}`
+				return execTmpl(tmpl, map[string]interface{}{
+					"name": v.name,
+					"num":  v.m,
+				})
+			}
 		}
 		tmpl := `{
 			subIndx := hh.Index()

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -909,7 +909,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 			}
 			// list
 			if hasTwoLists {
-				return &Value{t: TypeList, s: f, e: &Value{t: TypeBytes, c: sCheck, m: s}}, nil
+				return &Value{t: TypeList, s: f, m: f, e: &Value{t: TypeBytes, c: sCheck, m: s}}, nil
 			}
 			return &Value{t: TypeList, s: f, e: &Value{t: TypeBytes, c: sCheck, n: s, s: s}}, nil
 		}

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -905,7 +905,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 			}
 			if t == TypeVector {
 				// vector
-				return &Value{t: TypeVector, c: fCheck, n: f * s, s: f, e: &Value{t: TypeBytes, c: sCheck, n: s, s: 0}}, nil
+				return &Value{t: TypeVector, c: fCheck, n: f * s, s: f, e: &Value{t: TypeBytes, c: sCheck, n: s, s: s}}, nil
 			}
 			// list
 			if hasTwoLists {


### PR DESCRIPTION
This PR adds support for

```go
type ETHMergeTransactions struct {
	OpaqueList [][]byte `json:"opaque_list" ssz-size:"?,?" ssz-max:"2048,2048"`
}
```
Which does not exist before. Being able to specify `ssz-max:"2048,2048"` is important for the eth1 <> eth2 merge functionality