### PR TITLE
Exit with a non-zero status code when tool fails to encode

### DIFF
--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -42,6 +42,7 @@ func main() {
 
 	if err := encode(source, targets, output, includeList, experimental); err != nil {
 		fmt.Printf("[ERR]: %v", err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
As title describes. This will help with our build tooling at github.com/prysmaticlabs/prysm