### PR TITLE
sszgen: output formatting in case of error

### DIFF
--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -41,7 +41,7 @@ func main() {
 	includeList := decodeList(include)
 
 	if err := encode(source, targets, output, includeList, experimental); err != nil {
-		fmt.Printf("[ERR]: %v", err)
+		fmt.Printf("[ERR]: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Output before:
```
[ERR]: failed to encode SigningData: could not find struct with name 'Hash'exit status 1
```
After:
```
[ERR]: failed to encode SigningData: could not find struct with name 'Hash'
exit status 1
```