### PR TITLE
Chunk aligned merge upstream

### DIFF
--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -59,7 +59,7 @@ func (v *Value) hashRootsInner(elem Type) string {
 		paddedSize := nextChunkAlignment(int(v.e.s))
 		if paddedSize != int(v.e.s) {
 			subName = "padded"
-			padDeclare = fmt.Sprintf("padded = make([]byte, %d)", paddedSize)
+			padDeclare = fmt.Sprintf("padded := make([]byte, %d)", paddedSize)
 			padCopy = fmt.Sprintf("\ncopy(padded[0:%d], i[0:%d])\n", v.e.s, v.e.s)
 		}
 	}

--- a/sszgen/hash_test.go
+++ b/sszgen/hash_test.go
@@ -14,11 +14,11 @@ func normalizeGenerated(s string) string {
 	return strings.Join(result, "\n")
 }
 
-var expectedMisalignedInner = `padded = make([]byte, 64)
-if len(i) != 48 {
+var expectedMisalignedInner = `if len(i) != 48 {
 	err = ssz.ErrBytesLength
 	return
 }
+padded = make([]byte, 64)
 copy(padded[0:48], i[0:48])
 hh.Append(padded)`
 
@@ -26,7 +26,7 @@ var expectedAlignedInner = `if len(i) != 32 {
 	err = ssz.ErrBytesLength
 	return
 }
-hh.Append(padded)`
+hh.Append(i)`
 
 func TestHashRootInnerMisaligned(t *testing.T) {
 	e := TypeBytes

--- a/sszgen/hash_test.go
+++ b/sszgen/hash_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func normalizeGenerated(s string) string {
+	lines := strings.Split(s, "\n")
+	result := make([]string, 0)
+	for _, l := range lines {
+		result = append(result, strings.TrimSpace(l))
+	}
+	return strings.Join(result, "\n")
+}
+
+var expectedMisalignedInner = `padded = make([]byte, 64)
+if len(i) != 48 {
+	err = ssz.ErrBytesLength
+	return
+}
+copy(padded[0:48], i[0:48])
+hh.Append(padded)`
+
+var expectedAlignedInner = `if len(i) != 32 {
+	err = ssz.ErrBytesLength
+	return
+}
+hh.Append(padded)`
+
+func TestHashRootInnerMisaligned(t *testing.T) {
+	e := TypeBytes
+	v := &Value{
+		e: &Value{
+			c: false,
+			s: 48,
+		},
+	}
+	actual := v.hashRootsInner(e)
+	if normalizeGenerated(actual) != normalizeGenerated(expectedMisalignedInner) {
+		t.Errorf("want=%s, got=%s", expectedMisalignedInner, actual)
+	}
+}
+
+func TestHashRootAligned(t *testing.T) {
+	e := TypeBytes
+	v := &Value{
+		e: &Value{
+			c: false,
+			s: 32,
+		},
+	}
+	actual := v.hashRootsInner(e)
+	if normalizeGenerated(actual) != normalizeGenerated(expectedAlignedInner) {
+		t.Errorf("want=%s, got=%s", expectedAlignedInner, actual)
+	}
+}
+
+func TestNextChunkAlignemnt(t *testing.T) {
+	cases := []struct{
+		size int
+		aligned int
+	}{
+		{
+			size: 48,
+			aligned: 64,
+		},
+		{
+			size: 1,
+			aligned: 32,
+		},
+		{
+			size: 32,
+			aligned: 32,
+		},
+		{
+			size: 64,
+			aligned: 64,
+		},
+	}
+	for _, c := range cases {
+		if c.aligned != nextChunkAlignment(c.size) {
+			t.Errorf("Expected nextChunkAlignment(%d) == %d, got %d", c.size, c.size, nextChunkAlignment(c.size))
+		}
+	}
+}

--- a/sszgen/hash_test.go
+++ b/sszgen/hash_test.go
@@ -18,7 +18,7 @@ var expectedMisalignedInner = `if len(i) != 48 {
 	err = ssz.ErrBytesLength
 	return
 }
-padded = make([]byte, 64)
+padded := make([]byte, 64)
 copy(padded[0:48], i[0:48])
 hh.Append(padded)`
 


### PR DESCRIPTION
Adds padding for byte slices that are not multiples of the htr chunk size (32 bytes) to align to the next chunk boundary. Failing to do this yields incorrectly encoded values which fail spec tests. This surfaced in changes for Altair, which introduces a new field with aligned byte slices that are not pre-aligned to chunk boundaries.