### PR TITLE
Fix bytelist

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -94,7 +94,7 @@ func (h *Hasher) Reset() {
 	h.hash.Reset()
 }
 
-func (h *Hasher) appendBytes32(b []byte) {
+func (h *Hasher) AppendBytes32(b []byte) {
 	h.buf = append(h.buf, b...)
 	if rest := len(b) % 32; rest != 0 {
 		// pad zero bytes to the left
@@ -106,26 +106,26 @@ func (h *Hasher) appendBytes32(b []byte) {
 func (h *Hasher) PutUint64(i uint64) {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, i)
-	h.appendBytes32(buf)
+	h.AppendBytes32(buf)
 }
 
 // PutUint32 appends a uint32 in 32 bytes
 func (h *Hasher) PutUint32(i uint32) {
 	buf := make([]byte, 4)
 	binary.LittleEndian.PutUint32(buf, i)
-	h.appendBytes32(buf)
+	h.AppendBytes32(buf)
 }
 
 // PutUint16 appends a uint16 in 32 bytes
 func (h *Hasher) PutUint16(i uint16) {
 	buf := make([]byte, 2)
 	binary.LittleEndian.PutUint16(buf, i)
-	h.appendBytes32(buf)
+	h.AppendBytes32(buf)
 }
 
 // PutUint16 appends a uint16 in 32 bytes
 func (h *Hasher) PutUint8(i uint8) {
-	h.appendBytes32([]byte{byte(i)})
+	h.AppendBytes32([]byte{byte(i)})
 }
 
 func CalculateLimit(maxCapacity, numItems, size uint64) uint64 {
@@ -225,7 +225,7 @@ func (h *Hasher) PutBitlist(bb []byte, maxSize uint64) {
 
 	// merkleize the content with mix in length
 	indx := h.Index()
-	h.appendBytes32(h.tmp)
+	h.AppendBytes32(h.tmp)
 	h.MerkleizeWithMixin(indx, size, (maxSize+255)/256)
 }
 
@@ -241,14 +241,14 @@ func (h *Hasher) PutBool(b bool) {
 // PutBytes appends bytes
 func (h *Hasher) PutBytes(b []byte) {
 	if len(b) <= 32 {
-		h.appendBytes32(b)
+		h.AppendBytes32(b)
 		return
 	}
 
 	// if the bytes are longer than 32 we have to
 	// merkleize the content
 	indx := h.Index()
-	h.appendBytes32(b)
+	h.AppendBytes32(b)
 	h.Merkleize(indx)
 }
 

--- a/sszgen/bytelist_test.go
+++ b/sszgen/bytelist_test.go
@@ -1,0 +1,1 @@
+package main

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -190,7 +190,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 		if v.e.t == TypeBytes {
 			eName := "elem"
 			// ByteLists should be represented as Value with TypeBytes and .m set instead of .s (isFixed == true)
-			htrCall = v.e.hashTreeRoot(eName, false)
+			htrCall = v.e.hashTreeRoot(eName, true)
 		} else {
 			htrCall = execTmpl(`if err = elem.HashTreeRootWith(hh); err != nil {
 	return

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -56,7 +56,7 @@ func (v *Value) hashRoots(isList bool, elem Type) string {
 	} else {
 		// []uint64
 		appendFn = "Append" + uintVToName(v.e)
-		elemSize = uint64(v.e.n)
+		elemSize = uint64(v.e.fixedSize())
 	}
 
 	var merkleize string
@@ -138,7 +138,7 @@ func (v *Value) hashTreeRoot() string {
 		} else {
 			name = "::." + v.name
 		}
-		bitLen := v.n * 8
+		bitLen := v.fixedSize() * 8
 		return fmt.Sprintf("hh.PutUint%d(%s)", bitLen, name)
 
 	case TypeBitList:

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -127,7 +127,7 @@ func (v *Value) hashTreeRoot(name string) string {
 		err = ssz.ErrIncorrectListSize
 		return
     }
-	hh.Append({{.name}})
+	hh.PutBytes({{.name}})
 	hh.MerkleizeWithMixin(elemIndx, byteLen, ({{.maxLen}}+31)/32)
 }`
 			return execTmpl(tmpl, map[string]interface{}{

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -116,12 +116,12 @@ func (v *Value) hashTreeRoot() string {
 			// dynamic bytes require special handling, need length mixed in
 			tmpl := `{
 	elemIndx := hh.Index()
-	byteLen := uint64(len({{.name}}))
+	byteLen := uint64(len(::.{{.name}}))
 	if byteLen > {{.maxLen}} {
 		err = ssz.ErrIncorrectListSize
 		return
     }
-	hh.Append({{.name}})
+	hh.Append(::.{{.name}})
 	hh.MerkleizeWithMixin(elemIndx, byteLen, ({{.maxLen}}+31)/32)
 }`
 			return execTmpl(tmpl, map[string]interface{}{

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -190,7 +190,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 		if v.e.t == TypeBytes {
 			eName := "elem"
 			// ByteLists should be represented as Value with TypeBytes and .m set instead of .s (isFixed == true)
-			htrCall = v.e.hashTreeRoot(eName, true)
+			htrCall = v.e.hashTreeRoot(eName, false)
 		} else {
 			htrCall = execTmpl(`if err = elem.HashTreeRootWith(hh); err != nil {
 	return

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -122,7 +122,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 			// dynamic bytes require special handling, need length mixed in
 			hMethod := "PutBytes"
 			if appendBytes {
-				hMethod = "Append"
+				hMethod = "AppendBytes32"
 			}
 			tmpl := `{
 	elemIndx := hh.Index()

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -155,9 +155,10 @@ func parseInput(source string) (map[string]*ast.File, error) {
 			return nil, err
 		}
 		for _, v := range astFiles {
-			if !strings.HasSuffix(v.Name, "_test") {
-				files = v.Files
+			if strings.HasSuffix(v.Name, "_test") || v.Name == "ignore" {
+				continue
 			}
+			files = v.Files
 		}
 	} else {
 		// single file

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -947,7 +947,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 			if collectionExpr.Len != nil {
 				arrayLen, ok := collectionExpr.Len.(*ast.BasicLit)
 				if !ok {
-					return nil, fmt.Errorf("failed to parse field %s. byte array definition not understood by go/ast")
+					return nil, fmt.Errorf("failed to parse field %s. byte array definition not understood by go/ast", name)
 				}
 				a, err := strconv.ParseUint(arrayLen.Value, 0, 64)
 				if err != nil {
@@ -963,7 +963,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 					return nil, fmt.Errorf("unexpected type for fixed size array, name=%s, type=%s", name, collection.t.String())
 				}
 				if collection.s != *astSize {
-					return nil, fmt.Errorf("Unexpected mismatch between ssz-size and array fixed size, name=%s, ssz-size=%d, fixed=%s", name, collection.s, *astSize)
+					return nil, fmt.Errorf("Unexpected mismatch between ssz-size and array fixed size, name=%s, ssz-size=%d, fixed=%d", name, collection.s, *astSize)
 				}
 			}
 

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -248,8 +248,6 @@ const (
 	TypeContainer
 	// TypeReference is a SSZ reference
 	TypeReference
-	TypeDerp1
-	TypeDerp2
 )
 
 func (t Type) String() string {
@@ -272,10 +270,6 @@ func (t Type) String() string {
 		return "container"
 	case TypeReference:
 		return "reference"
-	case TypeDerp1:
-		return "derp1"
-	case TypeDerp2:
-		return "derp2"
 	default:
 		panic("not found")
 	}
@@ -944,7 +938,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 		}
 
 		collectionExpr := obj
-		outer := &Value{t: TypeDerp1}
+		outer := &Value{}
 		collection := outer
 		for _, dim := range dims {
 			if dim.IsVector() {
@@ -994,7 +988,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 				// we expect there to a subsequent dimension when the element type is an ArrayType
 				// so we update the expression and value container in preparation for the next iteration
 				collectionExpr = eeType
-				collection.e = &Value{t: TypeDerp2}
+				collection.e = &Value{}
 				collection = collection.e
 				continue
 			case *ast.Ident:
@@ -1161,7 +1155,7 @@ func (v *Value) isFixed() bool {
 	default:
 		// TypeUndefined should be the only type to fallthrough to this case
 		// TypeUndefined always means there is a fatal error in the parsing logic
-		panic(fmt.Errorf("is fixed not implemented for type %s", v.t.String()))
+		panic(fmt.Errorf("is fixed not implemented for type %s named %s", v.t.String(), v.name))
 	}
 }
 

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -248,6 +248,8 @@ const (
 	TypeContainer
 	// TypeReference is a SSZ reference
 	TypeReference
+	TypeDerp1
+	TypeDerp2
 )
 
 func (t Type) String() string {
@@ -270,6 +272,10 @@ func (t Type) String() string {
 		return "container"
 	case TypeReference:
 		return "reference"
+	case TypeDerp1:
+		return "derp1"
+	case TypeDerp2:
+		return "derp2"
 	default:
 		panic("not found")
 	}
@@ -938,7 +944,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 		}
 
 		collectionExpr := obj
-		outer := &Value{}
+		outer := &Value{t: TypeDerp1}
 		collection := outer
 		for _, dim := range dims {
 			if dim.IsVector() {
@@ -988,7 +994,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 				// we expect there to a subsequent dimension when the element type is an ArrayType
 				// so we update the expression and value container in preparation for the next iteration
 				collectionExpr = eeType
-				collection.e = &Value{}
+				collection.e = &Value{t: TypeDerp2}
 				collection = collection.e
 				continue
 			case *ast.Ident:

--- a/sszgen/marshal.go
+++ b/sszgen/marshal.go
@@ -29,7 +29,7 @@ func (e *env) marshal(name string, v *Value) string {
 	}
 	if !v.isFixed() {
 		// offset is the position where the offset starts
-		data["offset"] = fmt.Sprintf("offset := int(%d)\n", v.n)
+		data["offset"] = fmt.Sprintf("offset := int(%d)\n", v.fixedSize())
 	}
 	str := execTmpl(tmpl, data)
 	return appendObjSignature(str, v)
@@ -159,7 +159,7 @@ func (v *Value) marshalContainer(start bool) string {
 		})
 	}
 
-	offset := v.n
+	offset := v.fixedSize()
 	out := []string{}
 
 	for indx, i := range v.o {
@@ -170,7 +170,7 @@ func (v *Value) marshalContainer(start bool) string {
 		} else {
 			// write the offset
 			str = fmt.Sprintf("// Offset (%d) '%s'\ndst = ssz.WriteOffset(dst, offset)\n%s\n", indx, i.name, i.size("offset"))
-			offset += i.n
+			offset += i.fixedSize()
 		}
 		out = append(out, str)
 	}

--- a/sszgen/size.go
+++ b/sszgen/size.go
@@ -43,7 +43,7 @@ func (v *Value) fixedSize() uint64 {
 	case TypeContainer:
 		var fixed uint64
 		for _, f := range v.o {
-			if v.isFixed() {
+			if f.isFixed() {
 				fixed += f.fixedSize()
 			} else {
 				// we don't want variable size objects to recursively calculate their inner sizes

--- a/sszgen/size.go
+++ b/sszgen/size.go
@@ -43,7 +43,12 @@ func (v *Value) fixedSize() uint64 {
 	case TypeContainer:
 		var fixed uint64
 		for _, f := range v.o {
-			fixed += f.fixedSize()
+			if v.isFixed() {
+				fixed += f.fixedSize()
+			} else {
+				// we don't want variable size objects to recursively calculate their inner sizes
+				fixed += bytesPerLengthOffset
+			}
 		}
 		return fixed
 	default:

--- a/sszgen/size.go
+++ b/sszgen/size.go
@@ -30,10 +30,8 @@ func (e *env) size(name string, v *Value) string {
 }
 
 func (v *Value) fixedSize() uint64 {
-	if !v.isFixed() {
-		return bytesPerLengthOffset
-	}
-	if v.t == TypeVector {
+	switch v.t {
+	case TypeVector:
 		if v.e == nil {
 			panic(fmt.Sprintf("error computing size of empty vector %v for type name=%s", v, v.name))
 		}
@@ -42,15 +40,18 @@ func (v *Value) fixedSize() uint64 {
 		} else {
 			return v.s * bytesPerLengthOffset
 		}
-	}
-	if v.t == TypeContainer {
+	case TypeContainer:
 		var fixed uint64
 		for _, f := range v.o {
 			fixed += f.fixedSize()
 		}
 		return fixed
+	default:
+		if !v.isFixed() {
+			return bytesPerLengthOffset
+		}
+		return v.s
 	}
-	return v.s
 }
 
 func (v *Value) sizeContainer(name string, start bool) string {

--- a/sszgen/size.go
+++ b/sszgen/size.go
@@ -90,10 +90,10 @@ func (v *Value) size(name string) string {
 		if v.t == TypeContainer {
 			return v.sizeContainer(name, false)
 		}
-		if v.n == 1 {
+		if v.fixedSize() == 1 {
 			return name + "++"
 		}
-		return name + " += " + strconv.Itoa(int(v.n))
+		return name + " += " + strconv.Itoa(int(v.fixedSize()))
 	}
 
 	switch v.t {
@@ -111,7 +111,7 @@ func (v *Value) size(name string) string {
 
 	case TypeVector:
 		if v.e.isFixed() {
-			return fmt.Sprintf("%s += len(::.%s) * %d", name, v.name, v.e.n)
+			return fmt.Sprintf("%s += len(::.%s) * %d", name, v.name, v.e.fixedSize())
 		}
 		v.e.name = v.name + "[ii]"
 		tmpl := `for ii := 0; ii < len(::.{{.name}}); ii++ {

--- a/sszgen/tag_parser.go
+++ b/sszgen/tag_parser.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"text/scanner"
+)
+
+type tokenState int
+
+const (
+	tsBegin tokenState = iota
+	tsLabel
+	tsValue
+	tsCloseTick
+)
+
+type TagParser struct {
+	sc scanner.Scanner
+	buffer string
+}
+
+func (tp *TagParser) Init(tag string) {
+	sr := strings.NewReader(tag)
+	tp.sc = scanner.Scanner{}
+	tp.sc.Init(sr)
+	tp.sc.Filename = "tag"
+	tp.sc.Mode ^= scanner.ScanRawStrings
+}
+
+func (tp TagParser) GetSSZTags() map[string]string {
+	var labelStr string
+	var state tokenState
+	tags := make(map[string]string)
+	for tok := tp.sc.Scan(); tok != scanner.EOF; tok = tp.sc.Scan() {
+		if state == tsCloseTick {
+			panic("undefined behavior when scanning beyond the end of the tag")
+		}
+		txt := tp.sc.TokenText()
+		switch txt {
+		case "`":
+			if state == tsLabel {
+				state = tsCloseTick
+				continue
+			}
+			if state == tsBegin {
+				state = tsLabel
+				continue
+			}
+		case ":":
+			if state == tsLabel {
+				state = tsValue
+				continue
+			}
+		case "\"":
+			continue
+		default:
+			if state == tsValue {
+				tags[labelStr] = trimTagQuotes(string(txt))
+				state = tsLabel
+				labelStr = ""
+				continue
+			}
+			if state == tsLabel {
+				labelStr += string(txt)
+				continue
+			}
+		}
+	}
+	return tags
+}
+
+// cannot compare untyped nil to typed nil
+// this value gives us a nil with type of *int
+// to compare to ssz-size = '?' values
+var nilInt *int
+
+func extractSSZDimensions(tag string) ([]*SSZDimension, error) {
+	tp := &TagParser{}
+	tp.Init(tag)
+	// parse the ssz-max and ssz-size key/value pairs out of the tag
+	tags := tp.GetSSZTags()
+	sszSizes, sizeDefined := tags["ssz-size"]
+	sszMax, maxDefined:= tags["ssz-max"]
+	if !sizeDefined && !maxDefined {
+		return nil, fmt.Errorf("No ssz-size or ssz-max tags found for element.")
+	}
+
+	// split each tag by ",". each position in the csv represents a dimension of an n-dimensional array
+	sizeSplit := strings.Split(sszSizes, ",")
+	maxSplit := strings.Split(sszMax, ",")
+	// find the largest of the two dimensions. for backward compat we'll be permissive and let them be uneven
+	ndims := len(sizeSplit)
+	if len(maxSplit) > len(sizeSplit) {
+		ndims = len(maxSplit)
+	}
+	dims := make([]*SSZDimension, ndims)
+	for i := 0; i < ndims; i++ {
+		var szi, mxi string
+		if len(sizeSplit) > i {
+			szi = sizeSplit[i]
+		}
+		if len(maxSplit) > i {
+			mxi = maxSplit[i]
+		}
+		if szi == "?" && mxi == "?" {
+			return nil, fmt.Errorf("At dimension %d both ssz-size and ssz-max had a '?' value", i)
+		}
+		if szi == "?" {
+			if mxi == "" {
+				return nil, fmt.Errorf("missing (empty) value for ssz-max at dimesion %d", i)
+			}
+			m, err := strconv.Atoi(mxi)
+			if err != nil {
+				return nil, fmt.Errorf("atoi failed on value %s for ssz-max at dimension %d. err=%s", mxi, i, err)
+			}
+			dims[i] = &SSZDimension{
+				ListLength:  &m,
+			}
+		} else {
+			if szi == "" {
+				return nil, fmt.Errorf("missing (empty) value for ssz-size at dimesion %d", i)
+			}
+			s, err := strconv.Atoi(szi)
+			if err != nil {
+				return nil, fmt.Errorf("atoi failed on value %s for ssz-size at dimension %d. err=%s", szi, i, err)
+			}
+			dims[i] = &SSZDimension{
+				VectorLength:  &s,
+			}
+		}
+	}
+	return dims, nil
+}
+
+type SSZDimension struct {
+	VectorLength *int
+	ListLength *int
+}
+
+func (dim *SSZDimension) IsVector() bool {
+	return dim.VectorLength != nilInt
+}
+
+func (dim *SSZDimension) IsList() bool {
+	return dim.ListLength != nilInt
+}
+
+func (dim *SSZDimension) ListLen() int {
+	return *dim.ListLength
+}
+
+func (dim *SSZDimension) VectorLen() int {
+	return *dim.VectorLength
+}
+
+// ValueType returns a Type enum to be used in the construction of a fastssz Value type
+func (dim *SSZDimension) ValueType() Type {
+	if dim.IsVector() {
+		return TypeVector
+	}
+	if dim.IsList() {
+		return TypeList
+	}
+	return TypeUndefined
+}
+
+// ValueType returns ssz-max or ssz-size, to be used in the construction of a fastssz Value type
+func (dim *SSZDimension) ValueLen() uint64 {
+	if dim.IsList() {
+		return uint64(dim.ListLen())
+	}
+	if dim.IsVector() {
+		return uint64(dim.VectorLen())
+	}
+	return 0
+}
+
+func trimTagQuotes(s string) string {
+	if len(s) > 0 && s[0] == '"' {
+		s = s[1:]
+	}
+	if len(s) > 0 && s[len(s)-1] == '"' {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/sszgen/tagparse_test.go
+++ b/sszgen/tagparse_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"testing"
+
+)
+
+func TestTokens(t *testing.T) {
+	testTag := "`protobuf:\"bytes,2004,rep,name=historical_roots,json=historicalRoots,proto3\" json:\"historical_roots,omitempty\" ssz-max:\"16777216\" ssz-size:\"?,32\"`"
+	tp := &TagParser{}
+	tp.Init(testTag)
+	tags := tp.GetSSZTags()
+	sszSize, ok := tags["ssz-size"]
+	if !ok {
+		t.Errorf("ssz-size tag not present")
+	}
+	expectedSize := "?,32"
+	if sszSize != expectedSize {
+		t.Errorf("expected ssz-size value '%s', got '%s'", expectedSize, sszSize)
+	}
+	sszMax, ok := tags["ssz-max"]
+	if !ok {
+		t.Errorf("ssz-max tag not present")
+	}
+	expectedMax := "16777216"
+	if sszMax != expectedMax {
+		t.Errorf("expected ssz-max value '%s', got '%s'", expectedMax, sszMax)
+	}
+}
+
+func TestFullTag(t *testing.T) {
+	tag := "`protobuf:\"bytes,1002,opt,name=genesis_validators_root,json=genesisValidatorsRoot,proto3\" json:\"genesis_validators_root,omitempty\" ssz-size:\"32\"`"
+	_, err := extractSSZDimensions(tag)
+	if err != nil {
+		t.Errorf("Unexpected error calling extractSSZDimensions: %v", err)
+	}
+}
+
+func TestListOfVector(t *testing.T) {
+	tag := "`protobuf:\"bytes,2004,rep,name=historical_roots,json=historicalRoots,proto3\" json:\"historical_roots,omitempty\" ssz-max:\"16777216\" ssz-size:\"?,32\"`"
+	_, err := extractSSZDimensions(tag)
+	if err != nil {
+		t.Errorf("Unexpected error calling extractSSZDimensions: %v", err)
+	}
+}
+
+func TestWildcardSSZSize(t *testing.T)  {
+	tag := "`ssz-max:\"16777216\" ssz-size:\"?,32\"`"
+	dims, err := extractSSZDimensions(tag)
+	if err != nil {
+		t.Errorf("Unexpected error calling extractSSZDimensions: %v", err)
+	}
+	expectedDims := 2
+	if len(dims) != expectedDims {
+		t.Errorf("expected %d dimensions from ssz tags, got %d", expectedDims, len(dims))
+	}
+	if !dims[0].IsList() {
+		t.Errorf("Expected the first dimension to be a list")
+	}
+	if dims[0].IsVector() {
+		t.Errorf("Expected the first dimension to not be a vector")
+	}
+	if dims[0].ListLen() != 16777216 {
+		t.Errorf("Expected max size of list to be %d, got %d", 16777216, dims[0].ListLen())
+	}
+	if !dims[1].IsVector() {
+		t.Errorf("Expected the first dimension to be a vector")
+	}
+	if dims[1].IsList() {
+		t.Errorf("Expected the second dimension to not be a list")
+	}
+	if dims[1].VectorLen() != 32 {
+		t.Errorf("Expected size of vector to be %d, got %d", 32, dims[1].VectorLen())
+	}
+}
+
+func TestListOfList(t *testing.T) {
+	tag := "`protobuf:\"bytes,14,rep,name=transactions,proto3\" json:\"transactions,omitempty\" ssz-max:\"1048576,1073741824\" ssz-size:\"?,?\"`"
+	dims, err := extractSSZDimensions(tag)
+	if err != nil {
+		t.Errorf("Unexpected error calling extractSSZDimensions: %v", err)
+	}
+	expectedDims := 2
+	if len(dims) != expectedDims {
+		t.Errorf("expected %d dimensions from ssz tags, got %d", expectedDims, len(dims))
+	}
+	if !dims[0].IsList() {
+		t.Errorf("Expected both dimensions to be lists, but the first dimension is not")
+	}
+	if !dims[1].IsList() {
+		t.Errorf("Expected both dimensions to be lists, but the second dimension is not")
+	}
+	if dims[0].IsVector() {
+		t.Errorf("Expected neither dimension to be vector, but the first dimension is")
+	}
+	if dims[1].IsVector() {
+		t.Errorf("Expected neither dimension to be vector, but the second dimension is")
+	}
+	if dims[0].ListLen() != 1048576 {
+		t.Errorf("Expected ssz-max of first dimension to be %d, got %d", 1048576 , dims[0].ListLen())
+	}
+	if dims[1].ListLen() != 1073741824 {
+		t.Errorf("Expected ssz-max of first dimension to be %d, got %d", 1073741824, dims[1].ListLen())
+	}
+}

--- a/sszgen/tagparse_test.go
+++ b/sszgen/tagparse_test.go
@@ -103,3 +103,39 @@ func TestListOfList(t *testing.T) {
 		t.Errorf("Expected ssz-max of first dimension to be %d, got %d", 1073741824, dims[1].ListLen())
 	}
 }
+
+func TestOneDVector(t *testing.T) {
+	tag := "`protobuf:\"bytes,1,opt,name=randao_reveal,json=randaoReveal,proto3\" json:\"randao_reveal,omitempty\" ssz-size:\"96\""
+	dims, err := extractSSZDimensions(tag)
+	if err != nil {
+		t.Errorf("Unexpected error calling extractSSZDimensions: %v", err)
+	}
+	expectedDims := 1
+	if len(dims) != expectedDims {
+		t.Errorf("expected %d dimensions from ssz tags, got %d", expectedDims, len(dims))
+	}
+}
+
+func TestOneDList(t *testing.T) {
+	tag := "`protobuf:\"bytes,4,rep,name=proposer_slashings,json=proposerSlashings,proto3\" json:\"proposer_slashings,omitempty\" ssz-max:\"16\"`"
+	dims, err := extractSSZDimensions(tag)
+	if err != nil {
+		t.Errorf("Unexpected error calling extractSSZDimensions: %v", err)
+	}
+	expectedDims := 1
+	if len(dims) != expectedDims {
+		t.Errorf("expected %d dimensions from ssz tags, got %d", expectedDims, len(dims))
+	}
+}
+
+func TestNoDims(t *testing.T) {
+	tag := "`protobuf:\"bytes,2,opt,name=eth1_data,json=eth1Data,proto3\" json:\"eth1_data,omitempty\"`"
+	dims, err := extractSSZDimensions(tag)
+	if err == nil {
+		t.Errorf("expected error when calling extractSSZDimensions without ssz-size or ssz-max: %v", err)
+	}
+	expectedDims := 0
+	if len(dims) != expectedDims {
+		t.Errorf("expected %d dimensions from ssz tags, got %d", expectedDims, len(dims))
+	}
+}

--- a/sszgen/tree.go
+++ b/sszgen/tree.go
@@ -94,8 +94,8 @@ func (v *Value) getTree() string {
 			name = "::." + v.name
 		}
 
-		bitLen := v.n * 8
-		return fmt.Sprintf("w.AddUint%d(%s)", bitLen, name)
+		method := uintVToName(v)
+		return fmt.Sprintf("w.Add%s(%s)", method, name)
 
 	case TypeBitList:
 		panic("unimplemented")

--- a/sszgen/unmarshal.go
+++ b/sszgen/unmarshal.go
@@ -34,7 +34,7 @@ func (v *Value) unmarshal(dst string) string {
 			return fmt.Sprintf("copy(::.%s[:], %s)", v.name, dst)
 		}
 		validate := ""
-		if v.s == 0 {
+		if !v.isFixed() {
 			// dynamic bytes, we need to validate the size of the buffer
 			validate = fmt.Sprintf("if len(%s) > %d { return ssz.ErrBytesLength }\n", dst, v.m)
 		}

--- a/sszgen/unmarshal.go
+++ b/sszgen/unmarshal.go
@@ -228,7 +228,11 @@ func (v *Value) umarshalContainer(start bool, dst string) (str string) {
 
 		// How much it increases on every item
 		var incr uint64
-		incr = i.fixedSize()
+		if i.isFixed() {
+			incr = i.fixedSize()
+		} else {
+			incr = bytesPerLengthOffset
+		}
 
 		dst = fmt.Sprintf("%s[%d:%d]", "buf", o0, o0+incr)
 		o0 += incr

--- a/sszgen/validate.go
+++ b/sszgen/validate.go
@@ -3,18 +3,14 @@ package main
 func (v *Value) validate() string {
 	switch v.t {
 	case TypeBitList, TypeBytes:
-		cmp := "!="
-		if v.t == TypeBitList {
-			cmp = ">"
-		}
+		// this is a fixed-length array, not a slice, so it's size is a constant we don't need to check
 		if v.c {
 			return ""
 		}
-		// fixed []byte
-		size := v.s
-		if size == 0 {
-			// dynamic []byte
-			size = v.m
+		// for fixed size collections, we need to ensure the size is an exact match
+		cmp := "!="
+		// for variable size values, we want to ensure it doesn't exceed max size bound
+		if !v.isFixed() {
 			cmp = ">"
 		}
 
@@ -26,10 +22,11 @@ func (v *Value) validate() string {
 		return execTmpl(tmpl, map[string]interface{}{
 			"cmp":  cmp,
 			"name": v.name,
-			"size": size,
+			"size": v.s,
 		})
 
 	case TypeVector:
+		// this is a fixed-length array, not a slice, so it's size is a constant we don't need to check
 		if v.c {
 			return ""
 		}


### PR DESCRIPTION
(description copied from https://github.com/ferranbt/fastssz/pull/65 - note that I have added a number of comments to that PR for extra context, so it could be valuable to look at that PR there first)

 Currently the fastssz parser makes assumptions about ssz-size/ssz-max struct tags that do not allow us to support multi-dimensional lists. Also there are assumptions that byte lists do not need to be supported, resulting in incorrect generated code for List[byte, N] types, which do not mixin the list length. These issues prevent the prysm implementation of several Altair and Merge types from passing spectests:

Altair:

    BeaconState.PreviouEpochParticipation
    BeaconState.CurrentEpochParticipation
    note: we use []byte for these types, unlike fastssz fixtures which use uint8, so the previous fixes in fastssz did not address our specific problem.

Merge:

    ExecutionPayload.ExtraData
    ExecutionPayload.Transactions

This PR attempts to solve both of these issues in one set of changes, and make the parsing code for dealing with lists more robust and easier to follow, also adding a tag parsing implementation with unit tests. Some changes were also made to parsing code that deals with computing fixed sizes. Rather than determining different sizes at parsing time, a fixedSize method was added to the Value type allowing the computation to be deferred to codgen time and determined recursively.

There is one change to codegen code which affects existing code. Rather than looping over collection types using a for loop with an array offset counter, the generated code now uses a for _, elem := range construction. This simplfies code generation because we can assume the name of the subelement is equal to the loop variable and don't need to keep track of nested list access. As a bonus this code should also be marginally more efficient, as benchmarks have show that go generates more efficient code using the range-element pattern than it does when using offset counters.