### PR TITLE
Assert HashWalker interface

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -11,6 +11,8 @@ import (
 	"github.com/minio/sha256-simd"
 )
 
+var _ HashWalker = (*Hasher)(nil)
+
 var (
 	// ErrIncorrectByteSize means that the byte size is incorrect
 	ErrIncorrectByteSize = fmt.Errorf("incorrect byte size")

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,5 +1,7 @@
 package ssz
 
+var _ HashWalker = (*Wrapper)(nil)
+
 // ProofTree hashes a HashRoot object with a Hasher from
 // the default HasherPool
 func ProofTree(v HashRoot) (*Node, error) {


### PR DESCRIPTION
This PR adds an explicit assertion for the `HashWalker` interface for `Hasher` and `Wrapper`.