### PR TITLE
Make suffix an option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: deterministic hash digest for generated file [[GH-110](https://github.com/ferranbt/fastssz/issues/110)]
 - feat: Skip unit tests and `ssz` generate objects during parsing [[GH-114](https://github.com/ferranbt/fastssz/issues/114)]
 - fix: Add support for non-literal array lengths [[GH-108](https://github.com/ferranbt/fastssz/issues/108)]
+- feat: Add `--suffix` command line option [[GH-113](https://github.com/ferranbt/fastssz/issues/113)]
 
 # 0.1.2 (26 Aug, 2022)
 

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -31,12 +31,14 @@ func generate() {
 	var output string
 	var include string
 	var excludeObjs string
+	var suffix string
 
 	flag.StringVar(&source, "path", "", "")
 	flag.StringVar(&objsStr, "objs", "", "")
 	flag.StringVar(&excludeObjs, "exclude-objs", "", "Comma-separated list of types to exclude from output")
 	flag.StringVar(&output, "output", "", "")
 	flag.StringVar(&include, "include", "", "")
+	flag.StringVar(&suffix, "suffix", "encoding", "")
 
 	flag.Parse()
 
@@ -47,7 +49,14 @@ func generate() {
 		excludeTypeNames[name] = true
 	}
 
-	if err := generator.Encode(source, targets, output, includeList, excludeTypeNames); err != nil {
+	if !strings.HasPrefix(suffix, "_") {
+		suffix = fmt.Sprintf("_%s", suffix)
+	}
+	if !strings.HasSuffix(suffix, ".go") {
+		suffix = fmt.Sprintf("%s.go", suffix)
+	}
+
+	if err := generator.Encode(source, targets, output, includeList, excludeTypeNames, suffix); err != nil {
 		fmt.Printf("[ERR]: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
At current the encoded file name is hardcoded to have the suffix 'encoding'.  This allows the suffix to be changed as a command line option.