### PR TITLE
chore(deps): Unfork `gohashtree`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 eth2.0-spec-tests
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ There are some caveats required to use this functionality.
 
 ## Fast HashTreeRoot
 
-`Fastssz` integrates with Prysm [gohashtree](github.com/prysmaticlabs/gohashtree) library to do high performance and concurrent Sha256 hashing. It achieves a 2x performance improvement with respect to the normal sequential hashing. As of now, this feature is not yet enabled by default since it does not use the `gohashtree` main branch. Thus, a [fork](https://github.com/prysmaticlabs/gohashtree) of `gohashtree` with that branch is used. You can track the updates on [this](github.com/prysmaticlabs/gohashtree/issues/4) issue.
+`Fastssz` integrates with Prysm [gohashtree](github.com/prysmaticlabs/gohashtree) library to do high performance and concurrent Sha256 hashing. It achieves a 2x performance improvement with respect to the normal sequential hashing.
 
 In order to use this feature, enable manually the hash function in the Hasher like in the benchmark example.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ There are some caveats required to use this functionality.
 
 ## Fast HashTreeRoot
 
-`Fastssz` integrates with Prysm [gohashtree](https://github.com/prysmaticlabs/gohashtree) library to do high performance and concurrent Sha256 hashing. It achieves a 2x performance improvement with respect to the normal sequential hashing. As of now, this feature is not yet enabled by default since it does not use the `gohashtree` main branch. Thus, a [fork](https://github.com/umbracle/gohashtree) of `gohashtree` with that branch is used. You can track the updates on [this](https://github.com/prysmaticlabs/gohashtree/issues/4) issue.
+`Fastssz` integrates with Prysm [gohashtree](github.com/prysmaticlabs/gohashtree) library to do high performance and concurrent Sha256 hashing. It achieves a 2x performance improvement with respect to the normal sequential hashing. As of now, this feature is not yet enabled by default since it does not use the `gohashtree` main branch. Thus, a [fork](https://github.com/prysmaticlabs/gohashtree) of `gohashtree` with that branch is used. You can track the updates on [this](github.com/prysmaticlabs/gohashtree/issues/4) issue.
 
 In order to use this feature, enable manually the hash function in the Hasher like in the benchmark example.

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/golang/snappy v0.0.3
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/mapstructure v1.3.2
+	github.com/prysmaticlabs/gohashtree v0.0.4-beta
 	github.com/stretchr/testify v1.8.1
-	github.com/umbracle/gohashtree v0.0.2-alpha.0.20240116220325-8d974894cac9
 	gopkg.in/yaml.v2 v2.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYG
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkqOOVnWapUyeWro4=
+github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -19,10 +21,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/umbracle/gohashtree v0.0.2-alpha.0.20230207094856-5b775a815c10 h1:CQh33pStIp/E30b7TxDlXfM0145bn2e8boI30IxAhTg=
-github.com/umbracle/gohashtree v0.0.2-alpha.0.20230207094856-5b775a815c10/go.mod h1:x/Pa0FF5Te9kdrlZKJK82YmAkvL8+f989USgz6Jiw7M=
-github.com/umbracle/gohashtree v0.0.2-alpha.0.20240116220325-8d974894cac9 h1:ksdOx5rKt9I59ceXCNwf/Xa9JCPLPKtfbAf3qnTxUwE=
-github.com/umbracle/gohashtree v0.0.2-alpha.0.20240116220325-8d974894cac9/go.mod h1:x/Pa0FF5Te9kdrlZKJK82YmAkvL8+f989USgz6Jiw7M=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/umbracle/gohashtree"
+	"github.com/prysmaticlabs/gohashtree"
 )
 
 func TestDepth(t *testing.T) {
@@ -68,7 +68,7 @@ func TestHashGoHashTree(t *testing.T) {
 	buf = append(buf, a...)
 	buf = append(buf, b...)
 
-	gohashtree.Hash(buf, buf)
+	gohashtree.HashByteSlice(buf, buf)
 
 	fmt.Println(buf)
 }

--- a/spectests/structs_test.go
+++ b/spectests/structs_test.go
@@ -11,7 +11,7 @@ import (
 
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/golang/snappy"
-	"github.com/umbracle/gohashtree"
+	"github.com/prysmaticlabs/gohashtree"
 
 	"gopkg.in/yaml.v2"
 )
@@ -205,7 +205,7 @@ func checkSSZEncoding(t *testing.T, fork fork, fileName, structName string, base
 	}
 
 	// Root with gohashtree
-	hh := ssz.NewHasherWithHashFn(gohashtree.Hash)
+	hh := ssz.NewHasherWithHashFn(gohashtree.HashByteSlice)
 	if err := obj.HashTreeRootWith(hh); err != nil {
 		fatal("GohashtreeRoot", err)
 	}
@@ -297,7 +297,7 @@ func BenchmarkHashTreeRoot_SuperFast(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	hh := ssz.NewHasherWithHashFn(gohashtree.Hash)
+	hh := ssz.NewHasherWithHashFn(gohashtree.HashByteSlice)
 	for i := 0; i < b.N; i++ {
 		obj.HashTreeRootWith(hh)
 		hh.Reset()


### PR DESCRIPTION
@ferranbt prysm implemented the byte slice hasher you were maintaining a fork for.