### PR TITLE
Increase performance of repeat proving.

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -92,7 +92,6 @@ func (n *Node) Show(maxDepth int) {
 }
 
 func (n *Node) show(depth int, maxDepth int) {
-
 	space := ""
 	for i := 0; i < depth; i++ {
 		space += "\t"
@@ -287,6 +286,11 @@ func hashNode(n *Node) []byte {
 		panic("Tree incomplete")
 	}
 
+	if n.value != nil {
+		// This value has already been hashed, don't do the work again.
+		return n.value
+	}
+
 	if n.right.isEmpty {
 		result := hashFn(append(hashNode(n.left), n.right.value...))
 		n.value = result // Set the hash result on each node so that proofs can be generated for any level
@@ -337,6 +341,10 @@ func (n *Node) Prove(index int) (*Proof, error) {
 	}
 
 	proof.Hashes = hashes
+	if cur.value == nil {
+		// This is an intermediate node without a value; add the hash to it so that we're providing a suitable leaf value.
+		cur.value = hashNode(cur)
+	}
 	proof.Leaf = cur.value
 
 	return proof, nil


### PR DESCRIPTION
Repeatedly running `Prove()` against the same node can take a long time, as hashes are unconditionally recomputed.  This simple change checks for the presence of a value in an intermediate node before rehashing.

Performance difference as follows:

```
goos: linux
goarch: amd64
pkg: github.com/ferranbt/fastssz
cpu: 12th Gen Intel(R) Core(TM) i7-1265U
         │    before.txt    │              after.txt               │
         │      sec/op      │    sec/op     vs base                │
Prove-12   247529.077µ ± 5%   4.283µ ± 34%  -100.00% (p=0.002 n=6)
```

This also returns the value being proved even if it is an intermediate node.

Test for repeated proving and a benchmark for repeated proving included.