### PR TITLE
typo fix Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [chat badge]: https://img.shields.io/badge/chat-discord-%237289da
 [chat link]: https://discord.gg/85U6593geJ
 
-The FastSSZ project in this reposity is a combination of two things: a high performant low level library to work with SSZ encodings (root of this project) and the ([sszgen](./sszgen)) code generator that generates the SSZ encodings for Go structs using the SSZ library. By combining both, this library achieves peak Go native performance and zero memory allocation. The repository uses as test the official Ethereum SSZ tests ([spectests](./spectests/)) for the Consensus Spec data structures.
+The FastSSZ project in this repository is a combination of two things: a high performant low level library to work with SSZ encodings (root of this project) and the ([sszgen](./sszgen)) code generator that generates the SSZ encodings for Go structs using the SSZ library. By combining both, this library achieves peak Go native performance and zero memory allocation. The repository uses as test the official Ethereum SSZ tests ([spectests](./spectests/)) for the Consensus Spec data structures.
 
 If you are only looking for the Consensus data structures and types with the SSZ support, it is recommended to use [go-eth-consensus](https://github.com/umbracle/go-eth-consensus) instead, since it is already integrated with other parts of the Consensus stack, like the Beacon http API.
 


### PR DESCRIPTION
# Pull Request Title: Fix Typo in `README.md` (reposity → repository)

## Summary:
This pull request fixes the typo "reposity" to "repository" in the `README.md` file. The change ensures correct spelling in the documentation.

## Changes Made:
- Fixed the typo "reposity" to "repository" in the `README.md` file.

## Files Changed:
- `README.md`

## Testing:
- No testing is required since this change is limited to documentation and does not affect functionality.

## Additional Notes:
- Ensuring correct spelling enhances the clarity and professionalism of the documentation.

---

Thank you for reviewing this change!
