### PR TITLE
chore(ci): upgrade checkout to v4

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Go test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v1
         with:


### PR DESCRIPTION
Bumps checkout to v4 for future-proofing against Node 20 runner updates. Workflows compile the same.