### PR TITLE
chore: fixed spelling errors 

### DIFF
--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -255,7 +255,7 @@ func (v *Value) hashTreeRootContainer(start bool) string {
 	out := []string{}
 	for indx, i := range v.o {
 		// the call to hashTreeRoot below is ugly because it's currently hacked to support ByteLists
-		// the first argument allows the element name to be overriden when calling .HashTreeRoot on it
+		// the first argument allows the element name to be overridden when calling .HashTreeRoot on it
 		// used to specify the name "elem" when called as part of a for loop iteration. when the string
 		// is empty, it defaults to the .name parameter of the value
 		// the second field tells the code generator to specifically generate a call to AppendBytes32

--- a/sszgen/generator/tag_parser.go
+++ b/sszgen/generator/tag_parser.go
@@ -139,7 +139,7 @@ func extractSSZDimensions(tag string) ([]*SSZDimension, error) {
 		switch szi {
 		case "?", "":
 			if mxi == "?" || mxi == "" {
-				return nil, fmt.Errorf("no numeric ssz-size or ssz-max tag for value at dimesion %d", i)
+				return nil, fmt.Errorf("no numeric ssz-size or ssz-max tag for value at dimension %d", i)
 			}
 			m, err := strconv.Atoi(mxi)
 			if err != nil {


### PR DESCRIPTION
sszgen/generator/hash.go
`overriden` - `overridden`

sszgen/generator/tag_parser.go
`dimesion` - `dimension`