### PR TITLE
Update setup-go action to latest version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: "1.18"
       - name: Validate codegen


### PR DESCRIPTION
PR updates the GitHub Action `actions/setup-go` from version v1 to the latest stable version v4 for improved performance, security, and compatibility.  
Reference: https://github.com/actions/setup-go







