### PR TITLE
fix: add informative error message in safeReadOffset function

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -133,7 +133,7 @@ func ReadOffset(buf []byte) uint64 {
 
 func safeReadOffset(buf []byte) (uint64, []byte, error) {
 	if len(buf) < 4 {
-		return 0, nil, fmt.Errorf("")
+		return 0, nil, fmt.Errorf("buffer too short for offset reading")
 	}
 	offset := ReadOffset(buf)
 	return offset, buf[4:], nil


### PR DESCRIPTION
Replace empty error message with descriptive text to improve debugging experience.  This change makes error handling more robust by providing clear information about  the cause of failure when buffer is too short for offset reading.