### PR TITLE
Add internal IR

### DIFF
--- a/sszgen/generator/generator.go
+++ b/sszgen/generator/generator.go
@@ -845,7 +845,7 @@ func (e *env) generateIR() error {
 		name := obj.name
 
 		var valid bool
-		if e.targets == nil || len(e.targets) == 0 {
+		if len(e.targets) == 0 {
 			valid = true
 		} else {
 			valid = contains(name, e.targets)
@@ -1361,18 +1361,9 @@ func (v *Value) isFixed() bool {
 		return true
 	case *List:
 		return false
-	}
-
-	switch v.t {
-	// dynamic collection types
-	case TypeList:
-		return false
-	case TypeVector:
-		if v.e.t == TypeUndefined {
-			fmt.Printf("%s", v.name)
-		}
+	case *Vector:
 		return v.e.isFixed()
-	case TypeContainer:
+	case *Container:
 		for _, f := range v.o {
 			if f.t == TypeUndefined {
 				fmt.Printf("%s %s", v.name, f.name)
@@ -1384,6 +1375,9 @@ func (v *Value) isFixed() bool {
 		}
 		// if all values within the container are fixed, it is fixed
 		return true
+	}
+
+	switch v.t {
 	case TypeReference:
 		if v.s != 0 {
 			return true

--- a/sszgen/generator/generator.go
+++ b/sszgen/generator/generator.go
@@ -163,8 +163,6 @@ type Value struct {
 	name string
 	// name of the Go object this value represents
 	obj string
-	// array is fixed size. important for codegen to know so that code can be generated to interop with slices
-	c bool
 	// ref is the external reference if the struct is imported
 	// from another package
 	ref string
@@ -1045,7 +1043,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 			}
 		}
 		if astSize != nil {
-			outer.c = true
+			// outer.c = true
 		}
 
 		var innerTyp *Value

--- a/sszgen/generator/generator.go
+++ b/sszgen/generator/generator.go
@@ -176,8 +176,6 @@ type Value struct {
 	ref string
 	// new determines if the value is a pointer
 	noPtr bool
-	// isFixed allows us to explicitly mark fixed at parse time
-	fixed bool
 
 	v2 Value2
 }
@@ -1059,7 +1057,6 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 		}
 		if astSize != nil {
 			outer.c = true
-			outer.fixed = true
 		}
 
 		switch eeType := obj.Elt.(type) {
@@ -1132,7 +1129,6 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 				if dim.IsVector() {
 					// this is how we differentiate byte lists from byte vectors, rather than the usual approach
 					// of nesting a Value for the element within the .e attribute
-					outerRef.fixed = true
 				}
 				if dim.IsBitlist() {
 					outerRef.t = TypeBitList
@@ -1273,7 +1269,7 @@ func (e *env) parseASTFieldType(name, tags string, expr ast.Expr) (*Value, error
 			if !tailDim.IsVector() {
 				return nil, fmt.Errorf("bitvector tag parse failed (no ssz-size for last dim) %s, err=%s", name, err)
 			}
-			return &Value{t: TypeBytes, fixed: true, v2: &Bytes{Size: uint64(tailDim.VectorLen())}}, nil
+			return &Value{t: TypeBytes, v2: &Bytes{Size: uint64(tailDim.VectorLen())}}, nil
 		}
 		// external reference
 		vv, err := e.encodeItem(sel, tags)

--- a/sszgen/generator/generator.go
+++ b/sszgen/generator/generator.go
@@ -893,7 +893,7 @@ func (e *env) encodeItem(name, tags string) (*Value, error) {
 		}
 		if raw.implFunc {
 			size, _ := getTagsInt(tags, "ssz-size")
-			v = &Value{t: TypeReference, s: size, noPtr: raw.obj == nil}
+			v = &Value{t: TypeReference, s: size, noPtr: raw.obj == nil, v2: &Reference{Size: size}}
 		} else if raw.obj != nil {
 			v, err = e.parseASTStructType(name)
 		} else {

--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -193,14 +193,9 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 
 	case *Time:
 		return fmt.Sprintf("hh.PutUint64(uint64(%s.Unix()))", name)
-	}
 
-	switch v.t {
-	case TypeReference:
-		return v.hashTreeRootContainer(false)
-
-	case TypeBytes:
-		if v.c {
+	case *Bytes:
+		if !obj.IsGoDyn && !obj.IsList {
 			name += "[:]"
 		}
 		if v.isFixed() {
@@ -208,7 +203,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 			return execTmpl(tmpl, map[string]interface{}{
 				"validate": v.validate(),
 				"name":     name,
-				"size":     v.s,
+				"size":     obj.Size,
 			})
 		} else {
 			// dynamic bytes require special handling, need length mixed in
@@ -229,9 +224,14 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 			return execTmpl(tmpl, map[string]interface{}{
 				"hashMethod": hMethod,
 				"name":       name,
-				"maxLen":     v.m,
+				"maxLen":     obj.Size,
 			})
 		}
+	}
+
+	switch v.t {
+	case TypeReference:
+		return v.hashTreeRootContainer(false)
 
 	default:
 		panic(fmt.Errorf("hash not implemented for type %s", v.t.String()))

--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -126,7 +126,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 	}
 
 	switch obj := v.v2.(type) {
-	case *Container:
+	case *Container, *Reference:
 		return v.hashTreeRootContainer(false)
 
 	case *Uint:
@@ -227,11 +227,6 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 				"maxLen":     obj.Size,
 			})
 		}
-	}
-
-	switch v.t {
-	case TypeReference:
-		return v.hashTreeRootContainer(false)
 
 	default:
 		panic(fmt.Errorf("hash not implemented for type %s", v.t.String()))

--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -72,7 +72,7 @@ func (v *Value) hashRoots(isList bool) string {
 		// if the type is complex (TypeVector), the limit is the size.
 		// TODO: Generalize a list of complex objects
 		isComplex := false
-		if innerObj.t == TypeBytes {
+		if _, ok := innerObj.v2.(*Bytes); ok {
 			// TypeVector alias
 			isComplex = true
 		}
@@ -88,7 +88,7 @@ func (v *Value) hashRoots(isList bool) string {
 		})
 
 		// when doing []uint64 we need to round up the Hasher bytes to 32
-		if innerObj.t == TypeUint {
+		if _, ok := innerObj.v2.(*Uint); ok {
 			merkleize = "hh.FillUpTo32()\n" + merkleize
 		}
 	} else {
@@ -159,7 +159,10 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 
 	case *List:
 		if obj.Elem.isFixed() {
-			if obj.Elem.t == TypeUint || obj.Elem.t == TypeBytes {
+			_, isUint := obj.Elem.v2.(*Uint)
+			_, isBytes := obj.Elem.v2.(*Bytes)
+
+			if isUint || isBytes {
 				return v.hashRoots(true)
 			}
 		}
@@ -177,7 +180,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 			hh.MerkleizeWithMixin(subIndx, num, {{.num}})
 		}`
 		var htrCall string
-		if obj.Elem.t == TypeBytes {
+		if _, ok := obj.Elem.v2.(*Bytes); ok {
 			eName := "elem"
 			// ByteLists should be represented as Value with TypeBytes and .m set instead of .s (isFixed == true)
 			htrCall = obj.Elem.hashTreeRoot(eName, true)
@@ -231,7 +234,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 		}
 
 	default:
-		panic(fmt.Errorf("hash not implemented for type %s", v.t.String()))
+		panic(fmt.Errorf("hash not implemented for type %s", v.Type()))
 	}
 }
 

--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -30,9 +30,7 @@ func (v *Value) hashRoots(isList bool) string {
 	innerObj := getElem(v.v2)
 
 	subName := "i"
-	if innerObj.c {
-		subName += "[:]"
-	}
+
 	inner := ""
 	if obj, ok := innerObj.v2.(*Bytes); ok && (obj.IsGoDyn || obj.IsList) {
 		inner = `if len(i) != %d {
@@ -56,6 +54,11 @@ func (v *Value) hashRoots(isList bool) string {
 		} else {
 			appendFn = "Append"
 			elemSize = 32
+
+			if !obj.IsGoDyn {
+				// If we have something like [32]byte we need to call append with [:] to convert it to a slice
+				subName += "[:]"
+			}
 		}
 	} else {
 		// []uint64

--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -57,7 +57,7 @@ func (v *Value) hashRoots(isList bool) string {
 		}
 	} else {
 		// []uint64
-		appendFn = "Append" + uintVToName(v.e)
+		appendFn = "Append" + uintVToName2(*v.e.v2.(*Uint))
 		elemSize = uint64(v.e.fixedSize())
 	}
 

--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -45,6 +45,11 @@ func (v *Value) hashRoots(isList bool) string {
 	var elemSize uint64
 
 	if obj, ok := innerObj.typ.(*Bytes); ok {
+		if !obj.IsGoDyn {
+			// If we have something like [32]byte we need to call append with [:] to convert it to a slice
+			subName += "[:]"
+		}
+
 		// [][]byte
 		if obj.Size != 32 {
 			// we need to use PutBytes in order to hash the result since
@@ -54,11 +59,6 @@ func (v *Value) hashRoots(isList bool) string {
 		} else {
 			appendFn = "Append"
 			elemSize = 32
-
-			if !obj.IsGoDyn {
-				// If we have something like [32]byte we need to call append with [:] to convert it to a slice
-				subName += "[:]"
-			}
 		}
 	} else {
 		// []uint64

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -91,14 +91,14 @@ func getElem(v Value2) *Value {
 }
 
 func (v *Value) getObjs() []*Value {
-	if obj, ok := v.v2.(*Container); ok {
+	if obj, ok := v.typ.(*Container); ok {
 		return obj.Elems
 	}
 	return nil
 }
 
 func (v *Value) Type() string {
-	switch v.v2.(type) {
+	switch v.typ.(type) {
 	case *Bool:
 		return "bool"
 	case *Uint:
@@ -120,6 +120,6 @@ func (v *Value) Type() string {
 	case *Time:
 		return "time"
 	default:
-		panic(fmt.Errorf("unknown type %s", reflect.TypeOf(v.v2)))
+		panic(fmt.Errorf("unknown type %s", reflect.TypeOf(v.typ)))
 	}
 }

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -63,3 +63,9 @@ type Time struct {
 }
 
 func (t *Time) isValue() {}
+
+type Reference struct {
+	Size uint64
+}
+
+func (r *Reference) isValue() {}

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -1,0 +1,70 @@
+package generator
+
+// vector -> fixed size
+// list -> variable size
+
+type Value2 interface {
+	isValue()
+}
+
+type Uint struct {
+	Size uint64
+}
+
+func (u *Uint) isValue() {}
+
+type Int struct {
+	Size uint64
+}
+
+func (i *Int) isValue() {}
+
+type Bool struct {
+}
+
+func (b *Bool) isValue() {}
+
+type Bytes struct {
+	Size  uint64
+	IsDyn bool // this is a fixed byte array but that is represented as a vector
+}
+
+func (b *Bytes) isValue() {}
+
+type DynamicBytes struct {
+	MaxSize uint64
+}
+
+func (d *DynamicBytes) isValue() {}
+
+type BitList struct {
+	Size uint64
+}
+
+func (b *BitList) isValue() {}
+
+type Vector struct {
+	Elem  Value2
+	Size  uint64
+	IsDyn bool // this is a fixed byte array but that is represented as a vector
+}
+
+func (v *Vector) isValue() {}
+
+type List struct {
+	Elem    Value2
+	MaxSize uint64
+}
+
+func (l *List) isValue() {}
+
+type Container struct {
+	Elems map[string]*Value
+}
+
+func (c *Container) isValue() {}
+
+type Time struct {
+}
+
+func (t *Time) isValue() {}

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -25,17 +25,12 @@ type Bool struct {
 func (b *Bool) isValue() {}
 
 type Bytes struct {
-	Size  uint64
-	IsDyn bool // this is a fixed byte array but that is represented as a vector
+	Size    uint64
+	IsList  bool
+	IsGoDyn bool // this is a fixed byte array but that is represented as a vector
 }
 
 func (b *Bytes) isValue() {}
-
-type DynamicBytes struct {
-	MaxSize uint64
-}
-
-func (d *DynamicBytes) isValue() {}
 
 type BitList struct {
 	Size uint64

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -1,5 +1,10 @@
 package generator
 
+import (
+	"fmt"
+	"reflect"
+)
+
 // vector -> fixed size
 // list -> variable size
 
@@ -39,7 +44,7 @@ type BitList struct {
 func (b *BitList) isValue() {}
 
 type Vector struct {
-	Elem  Value2
+	Elem  *Value
 	Size  uint64
 	IsDyn bool // this is a fixed byte array but that is represented as a vector
 }
@@ -47,14 +52,14 @@ type Vector struct {
 func (v *Vector) isValue() {}
 
 type List struct {
-	Elem    Value2
+	Elem    *Value
 	MaxSize uint64
 }
 
 func (l *List) isValue() {}
 
 type Container struct {
-	Elems map[string]*Value
+	Elems []*Value
 }
 
 func (c *Container) isValue() {}
@@ -69,3 +74,21 @@ type Reference struct {
 }
 
 func (r *Reference) isValue() {}
+
+func getElem(v Value2) *Value {
+	switch obj := v.(type) {
+	case *List:
+		return obj.Elem
+	case *Vector:
+		return obj.Elem
+	default:
+		panic(fmt.Errorf("getElem called with non-list/vector type %s", reflect.TypeOf(v)))
+	}
+}
+
+func (v *Value) getObjs() []*Value {
+	if obj, ok := v.v2.(*Container); ok {
+		return obj.Elems
+	}
+	return nil
+}

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -92,3 +92,30 @@ func (v *Value) getObjs() []*Value {
 	}
 	return nil
 }
+
+func (v *Value) Type() string {
+	switch v.v2.(type) {
+	case *Bool:
+		return "bool"
+	case *Uint:
+		return "uint"
+	case *Int:
+		return "int"
+	case *Bytes:
+		return "bytes"
+	case *BitList:
+		return "bitlist"
+	case *Vector:
+		return "vector"
+	case *List:
+		return "list"
+	case *Container:
+		return "container"
+	case *Reference:
+		return "reference"
+	case *Time:
+		return "time"
+	default:
+		panic(fmt.Errorf("unknown type %s", reflect.TypeOf(v.v2)))
+	}
+}

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -35,6 +35,10 @@ type Bytes struct {
 	IsGoDyn bool // this is a fixed byte array but that is represented as a vector
 }
 
+func (b *Bytes) IsFixed() bool {
+	return !b.IsList && !b.IsGoDyn
+}
+
 func (b *Bytes) isValue() {}
 
 type BitList struct {

--- a/sszgen/generator/marshal.go
+++ b/sszgen/generator/marshal.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 )
 
@@ -82,7 +81,7 @@ func (v *Value) marshal() string {
 		return v.marshalContainer(false)
 
 	default:
-		panic(fmt.Errorf("marshal not implemented for type %s: %v", v.t.String(), reflect.TypeOf(v.v2)))
+		panic(fmt.Errorf("marshal not implemented for type %s", v.Type()))
 	}
 }
 

--- a/sszgen/generator/marshal.go
+++ b/sszgen/generator/marshal.go
@@ -42,7 +42,7 @@ func (v *Value) marshal() string {
 
 	case *Bytes:
 		name := v.name
-		if v.c {
+		if obj.IsFixed() {
 			name += "[:]"
 		}
 		tmpl := `{{.validate}}dst = append(dst, ::.{{.name}}...)`

--- a/sszgen/generator/marshal.go
+++ b/sszgen/generator/marshal.go
@@ -37,7 +37,7 @@ func (e *env) marshal(name string, v *Value) string {
 }
 
 func (v *Value) marshal() string {
-	switch v.v2.(type) {
+	switch obj := v.v2.(type) {
 	case *Bool:
 		return fmt.Sprintf("dst = ssz.MarshalBool(dst, ::.%s)", v.name)
 
@@ -57,11 +57,11 @@ func (v *Value) marshal() string {
 		var name string
 		if v.ref != "" || v.obj != "" {
 			// alias to uint*
-			name = fmt.Sprintf("%s(::.%s)", uintVToLowerCaseName(v), v.name)
+			name = fmt.Sprintf("%s(::.%s)", uintVToLowerCaseName2(obj), v.name)
 		} else {
 			name = "::." + v.name
 		}
-		return fmt.Sprintf("dst = ssz.Marshal%s(dst, %s)", uintVToName(v), name)
+		return fmt.Sprintf("dst = ssz.Marshal%s(dst, %s)", uintVToName2(*obj), name)
 
 	case *BitList:
 		return fmt.Sprintf("%sdst = append(dst, ::.%s...)", v.validate(), v.name)

--- a/sszgen/generator/marshal.go
+++ b/sszgen/generator/marshal.go
@@ -36,7 +36,7 @@ func (e *env) marshal(name string, v *Value) string {
 }
 
 func (v *Value) marshal() string {
-	switch obj := v.v2.(type) {
+	switch obj := v.typ.(type) {
 	case *Bool:
 		return fmt.Sprintf("dst = ssz.MarshalBool(dst, ::.%s)", v.name)
 
@@ -86,7 +86,7 @@ func (v *Value) marshal() string {
 }
 
 func (v *Value) marshalList() string {
-	inner := getElem(v.v2)
+	inner := getElem(v.typ)
 	inner.name = v.name + "[ii]"
 
 	// bound check
@@ -127,9 +127,9 @@ func (v *Value) marshalList() string {
 }
 
 func (v *Value) marshalVector() (str string) {
-	inner := getElem(v.v2)
+	inner := getElem(v.typ)
 
-	obj := v.v2.(*Vector)
+	obj := v.typ.(*Vector)
 	inner.name = fmt.Sprintf("%s[ii]", v.name)
 
 	tmpl := `{{.validate}}for ii := 0; ii < {{.size}}; ii++ {

--- a/sszgen/generator/marshal.go
+++ b/sszgen/generator/marshal.go
@@ -41,7 +41,7 @@ func (v *Value) marshal() string {
 	case *Bool:
 		return fmt.Sprintf("dst = ssz.MarshalBool(dst, ::.%s)", v.name)
 
-	case *Bytes, *DynamicBytes:
+	case *Bytes:
 		name := v.name
 		if v.c {
 			name += "[:]"

--- a/sszgen/generator/marshal.go
+++ b/sszgen/generator/marshal.go
@@ -78,12 +78,7 @@ func (v *Value) marshal() string {
 		}
 		return v.marshalList()
 
-	case *Container:
-		return v.marshalContainer(false)
-	}
-
-	switch v.t {
-	case TypeReference:
+	case *Container, *Reference:
 		return v.marshalContainer(false)
 
 	default:

--- a/sszgen/generator/size.go
+++ b/sszgen/generator/size.go
@@ -31,7 +31,7 @@ func (e *env) size(name string, v *Value) string {
 }
 
 func (v *Value) fixedSize() uint64 {
-	switch obj := v.v2.(type) {
+	switch obj := v.typ.(type) {
 	case *Bool:
 		return 1
 	case *Uint:
@@ -67,7 +67,7 @@ func (v *Value) fixedSize() uint64 {
 		return obj.Size
 
 	default:
-		panic(fmt.Errorf("fixed size not implemented for type %s", reflect.TypeOf(v.v2)))
+		panic(fmt.Errorf("fixed size not implemented for type %s", reflect.TypeOf(v.typ)))
 	}
 }
 
@@ -105,7 +105,7 @@ func (v *Value) sizeContainer(name string, start bool) string {
 // during marshalling to figure out the size of the offset
 func (v *Value) size(name string) string {
 	if v.isFixed() {
-		if _, ok := v.v2.(*Container); ok {
+		if _, ok := v.typ.(*Container); ok {
 			return v.sizeContainer(name, false)
 		}
 		if v.fixedSize() == 1 {
@@ -114,7 +114,7 @@ func (v *Value) size(name string) string {
 		return name + " += " + strconv.Itoa(int(v.fixedSize()))
 	}
 
-	switch v.v2.(type) {
+	switch v.typ.(type) {
 	case *Container, *Reference:
 		return v.sizeContainer(name, false)
 
@@ -125,7 +125,7 @@ func (v *Value) size(name string) string {
 		return fmt.Sprintf(name+" += len(::.%s)", v.name)
 
 	case *List, *Vector:
-		inner := getElem(v.v2)
+		inner := getElem(v.typ)
 
 		if inner.isFixed() {
 			return fmt.Sprintf("%s += len(::.%s) * %d", name, v.name, inner.fixedSize())

--- a/sszgen/generator/size.go
+++ b/sszgen/generator/size.go
@@ -60,13 +60,13 @@ func (v *Value) fixedSize() uint64 {
 			return obj.Size * bytesPerLengthOffset
 		}
 
-	default:
-		if v.t == TypeReference {
-			if !v.isFixed() {
-				return bytesPerLengthOffset
-			}
-			return v.s
+	case *Reference:
+		if !v.isFixed() {
+			return bytesPerLengthOffset
 		}
+		return obj.Size
+
+	default:
 		panic(fmt.Errorf("fixed size not implemented for type %s", reflect.TypeOf(v.v2)))
 	}
 }
@@ -115,7 +115,7 @@ func (v *Value) size(name string) string {
 	}
 
 	switch v.v2.(type) {
-	case *Container:
+	case *Container, *Reference:
 		return v.sizeContainer(name, false)
 
 	case *BitList:
@@ -138,11 +138,6 @@ func (v *Value) size(name string) string {
 			"size":    name,
 			"dynamic": v.e.size(name),
 		})
-	}
-
-	switch v.t {
-	case TypeReference:
-		return v.sizeContainer(name, false)
 
 	default:
 		panic(fmt.Errorf("size not implemented for type %s", v.t.String()))

--- a/sszgen/generator/size.go
+++ b/sszgen/generator/size.go
@@ -105,7 +105,7 @@ func (v *Value) sizeContainer(name string, start bool) string {
 // during marshalling to figure out the size of the offset
 func (v *Value) size(name string) string {
 	if v.isFixed() {
-		if v.t == TypeContainer {
+		if _, ok := v.v2.(*Container); ok {
 			return v.sizeContainer(name, false)
 		}
 		if v.fixedSize() == 1 {
@@ -142,6 +142,6 @@ func (v *Value) size(name string) string {
 		})
 
 	default:
-		panic(fmt.Errorf("size not implemented for type %s", v.t.String()))
+		panic(fmt.Errorf("size not implemented for type %s", v.Type()))
 	}
 }

--- a/sszgen/generator/size.go
+++ b/sszgen/generator/size.go
@@ -40,8 +40,6 @@ func (v *Value) fixedSize() uint64 {
 		return obj.Size
 	case *Bytes:
 		return obj.Size
-	case *DynamicBytes:
-		return obj.MaxSize
 	case *BitList:
 		return obj.Size
 	case *Container:

--- a/sszgen/generator/tag_parser.go
+++ b/sszgen/generator/tag_parser.go
@@ -8,6 +8,9 @@ import (
 	"text/scanner"
 )
 
+// Vector -> fixed size
+// List -> variable size
+
 type tokenState int
 
 const (
@@ -168,6 +171,19 @@ type SSZDimension struct {
 	VectorLength *int
 	ListLength   *int
 	isBitlist    bool
+}
+
+func (dim *SSZDimension) Type() string {
+	if dim.IsVector() {
+		return "vector"
+	}
+	if dim.IsList() {
+		return "list"
+	}
+	if dim.IsBitlist() {
+		return "bitlist"
+	}
+	return "undefined"
 }
 
 func (dim *SSZDimension) IsVector() bool {

--- a/sszgen/generator/tag_parser.go
+++ b/sszgen/generator/tag_parser.go
@@ -206,17 +206,6 @@ func (dim *SSZDimension) VectorLen() int {
 	return *dim.VectorLength
 }
 
-// ValueType returns a Type enum to be used in the construction of a fastssz Value type
-func (dim *SSZDimension) ValueType() Type {
-	if dim.IsVector() {
-		return TypeVector
-	}
-	if dim.IsList() {
-		return TypeList
-	}
-	return TypeUndefined
-}
-
 // ValueType returns ssz-max or ssz-size, to be used in the construction of a fastssz Value type
 func (dim *SSZDimension) ValueLen() uint64 {
 	if dim.IsList() {

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -328,10 +328,13 @@ func (v *Value) umarshalContainer(start bool, dst string) (str string) {
 // createItem is used to initialize slices of objects
 func (v *Value) createSlice(useNumVariable bool) string {
 	var sizeU64 uint64
+	var isVectorCreate bool
 	if obj, ok := v.v2.(*List); ok {
 		sizeU64 = obj.MaxSize
+		isVectorCreate = true
 	} else if obj, ok := v.v2.(*Vector); ok {
 		sizeU64 = obj.Size
+		isVectorCreate = obj.IsDyn
 	} else {
 		panic("BUG: create item is only intended to be used with vectors and lists")
 	}
@@ -357,7 +360,7 @@ func (v *Value) createSlice(useNumVariable bool) string {
 		return fmt.Sprintf("::.%s = make([]%s%s, %s)", v.name, ptr, inner.objRef(), size)
 
 	case *Bytes:
-		if v.c {
+		if !isVectorCreate {
 			return ""
 		}
 
@@ -367,7 +370,7 @@ func (v *Value) createSlice(useNumVariable bool) string {
 			return fmt.Sprintf("::.%s = make([]%s, %s)", v.name, ref, size)
 		}
 
-		if inner.c {
+		if obj.IsFixed() {
 			return fmt.Sprintf("::.%s = make([][%d]byte, %s)", v.name, obj.Size, size)
 		}
 

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -24,7 +24,7 @@ func (e *env) unmarshal(name string, v *Value) string {
 }
 
 func (v *Value) unmarshal(dst string) string {
-	switch obj := v.v2.(type) {
+	switch obj := v.typ.(type) {
 	case *Container, *Reference:
 		return v.umarshalContainer(false, dst)
 
@@ -110,15 +110,15 @@ func (v *Value) unmarshal(dst string) string {
 
 func (v *Value) unmarshalList() string {
 	var size uint64
-	if obj, ok := v.v2.(*List); ok {
+	if obj, ok := v.typ.(*List); ok {
 		size = obj.MaxSize
-	} else if obj, ok := v.v2.(*Vector); ok {
+	} else if obj, ok := v.typ.(*Vector); ok {
 		size = obj.Size
 	} else {
 		panic(fmt.Errorf("unmarshalList not implemented for type %s", v.Type()))
 	}
 
-	inner := getElem(v.v2)
+	inner := getElem(v.typ)
 	if inner.isFixed() {
 		dst := fmt.Sprintf("buf[ii*%d: (ii+1)*%d]", inner.fixedSize(), inner.fixedSize())
 
@@ -329,10 +329,10 @@ func (v *Value) umarshalContainer(start bool, dst string) (str string) {
 func (v *Value) createSlice(useNumVariable bool) string {
 	var sizeU64 uint64
 	var isVectorCreate bool
-	if obj, ok := v.v2.(*List); ok {
+	if obj, ok := v.typ.(*List); ok {
 		sizeU64 = obj.MaxSize
 		isVectorCreate = true
-	} else if obj, ok := v.v2.(*Vector); ok {
+	} else if obj, ok := v.typ.(*Vector); ok {
 		sizeU64 = obj.Size
 		isVectorCreate = obj.IsDyn
 	} else {
@@ -345,8 +345,8 @@ func (v *Value) createSlice(useNumVariable bool) string {
 		size = "num"
 	}
 
-	inner := getElem(v.v2)
-	switch obj := inner.v2.(type) {
+	inner := getElem(v.typ)
+	switch obj := inner.typ.(type) {
 	case *Uint:
 		// []int uses the Extend functions in the fastssz package
 		return fmt.Sprintf("::.%s = ssz.Extend%s(::.%s, %s)", v.name, uintVToName2(*obj), v.name, size)

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -25,7 +25,7 @@ func (e *env) unmarshal(name string, v *Value) string {
 
 func (v *Value) unmarshal(dst string) string {
 	switch obj := v.v2.(type) {
-	case *Container:
+	case *Container, *Reference:
 		return v.umarshalContainer(false, dst)
 
 	case *Bytes:
@@ -102,12 +102,6 @@ func (v *Value) unmarshal(dst string) string {
 
 	case *List:
 		return v.unmarshalList()
-	}
-
-	// we use dst as the input buffer where the SSZ data to decode the value is.
-	switch v.t {
-	case TypeReference:
-		return v.umarshalContainer(false, dst)
 
 	default:
 		panic(fmt.Errorf("unmarshal not implemented for type %d", v.t))

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -348,7 +348,7 @@ func (v *Value) createSlice(useNumVariable bool) string {
 	switch obj := v.e.v2.(type) {
 	case *Uint:
 		// []int uses the Extend functions in the fastssz package
-		return fmt.Sprintf("::.%s = ssz.Extend%s(::.%s, %s)", v.name, uintVToName(v.e), v.name, size)
+		return fmt.Sprintf("::.%s = ssz.Extend%s(::.%s, %s)", v.name, uintVToName2(*obj), v.name, size)
 
 	case *Container:
 		// []*(ref.)Struct{}

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -104,7 +104,7 @@ func (v *Value) unmarshal(dst string) string {
 		return v.unmarshalList()
 
 	default:
-		panic(fmt.Errorf("unmarshal not implemented for type %d", v.t))
+		panic(fmt.Errorf("unmarshal not implemented for type %s", v.Type()))
 	}
 }
 
@@ -115,7 +115,7 @@ func (v *Value) unmarshalList() string {
 	} else if obj, ok := v.v2.(*Vector); ok {
 		size = obj.Size
 	} else {
-		panic(fmt.Errorf("unmarshalList not implemented for type %s", v.t.String()))
+		panic(fmt.Errorf("unmarshalList not implemented for type %s", v.Type()))
 	}
 
 	inner := getElem(v.v2)
@@ -136,10 +136,6 @@ func (v *Value) unmarshalList() string {
 			"create":    v.createSlice(true),
 			"unmarshal": inner.unmarshal(dst),
 		})
-	}
-
-	if v.t == TypeVector {
-		panic("it cannot happen")
 	}
 
 	// Decode list with a dynamic element. 'ssz.DecodeDynamicLength' ensures
@@ -378,6 +374,6 @@ func (v *Value) createSlice(useNumVariable bool) string {
 		return fmt.Sprintf("::.%s = make([][]byte, %s)", v.name, size)
 
 	default:
-		panic(fmt.Sprintf("create not implemented for %s type %s", v.name, inner.t.String()))
+		panic(fmt.Sprintf("create not implemented for %s type %s", v.name, inner.Type()))
 	}
 }

--- a/sszgen/generator/validate.go
+++ b/sszgen/generator/validate.go
@@ -20,7 +20,7 @@ func validateBytesArray(name string, size uint64, fixed bool) string {
 }
 
 func (v *Value) validate() string {
-	switch obj := v.v2.(type) {
+	switch obj := v.typ.(type) {
 	case *BitList:
 		return validateBytesArray(v.name, obj.Size, false)
 	case *Bytes:

--- a/sszgen/generator/validate.go
+++ b/sszgen/generator/validate.go
@@ -23,11 +23,12 @@ func (v *Value) validate() string {
 	switch obj := v.v2.(type) {
 	case *BitList:
 		return validateBytesArray(v.name, obj.Size, false)
-	case *DynamicBytes:
-		// always validate dynamic bytes
-		return validateBytesArray(v.name, obj.MaxSize, false)
 	case *Bytes:
-		if obj.IsDyn {
+		if obj.IsList {
+			// for lists of bytes, we need to validate the size of the buffer
+			return validateBytesArray(v.name, obj.Size, false)
+		}
+		if obj.IsGoDyn {
 			// always validate dynamic bytes
 			return validateBytesArray(v.name, obj.Size, true)
 		}


### PR DESCRIPTION
This PR introduces an internal Intermediate Representation (IR) system to replace the existing type handling approach in the fastssz code generator. The change refactors the type system from using simple enum-based types (TypeBytes, TypeUint, etc.) to a more structured interface-based design with specific type structs (*Bytes, *Uint, *Vector, etc.).
