### PR TITLE
Remove unmarshal boilerplate for dynamic size fields

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -42,12 +42,15 @@ func ErrListTooBigFn(name string, found, max int) error {
 
 // UnmarshalBytes unmarshals a byte slice from the src input
 // If the src is nil, it will create a new byte slice with the content of buf.
-func UnmarshalBytes(src []byte, buf []byte) []byte {
+func UnmarshalBytes(src []byte, buf []byte, expectedSize ...int) ([]byte, error) {
+	if len(expectedSize) > 0 && len(buf) != expectedSize[0] {
+		return nil, ErrBytesLength
+	}
 	if cap(src) == 0 {
 		src = make([]byte, 0, len(buf))
 	}
 	src = append(src, buf...)
-	return src
+	return src, nil
 }
 
 // UnmarshallUint64 unmarshals a little endian uint64 from the src input

--- a/encode.go
+++ b/encode.go
@@ -42,8 +42,8 @@ func ErrListTooBigFn(name string, found, max int) error {
 
 // UnmarshalBytes unmarshals a byte slice from the src input
 // If the src is nil, it will create a new byte slice with the content of buf.
-func UnmarshalBytes(src []byte, buf []byte, expectedSize ...int) ([]byte, error) {
-	if len(expectedSize) > 0 && len(buf) != expectedSize[0] {
+func UnmarshalBytes(src []byte, buf []byte, maxSize ...int) ([]byte, error) {
+	if len(maxSize) > 0 && len(buf) > maxSize[0] {
 		return nil, ErrBytesLength
 	}
 	if cap(src) == 0 {

--- a/interface.go
+++ b/interface.go
@@ -56,3 +56,43 @@ func UnmarshalField[T any, PT PtrConstraint[T]](field *PT, buf []byte) error {
 	}
 	return (*field).UnmarshalSSZ(buf)
 }
+
+// UnmarshalSliceWithIndexCallback handles slices with index-aware unmarshal logic
+func UnmarshalSliceWithIndexCallback[T any](
+	slice *[]T,
+	buf []byte,
+	itemSize int,
+	maxItems int,
+	unmarshalCallback func(int, []byte) error,
+) error {
+	num, err := DivideInt2(len(buf), itemSize, maxItems)
+	if err != nil {
+		return err
+	}
+
+	*slice = make([]T, num)
+	for ii := 0; ii < num; ii++ {
+		start := ii * itemSize
+		end := (ii + 1) * itemSize
+		if err := unmarshalCallback(ii, buf[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalDynamicSliceWithCallback handles dynamic slices with custom unmarshal logic
+func UnmarshalDynamicSliceWithCallback[T any](
+	slice *[]T,
+	buf []byte,
+	maxElements int,
+	unmarshalCallback func(int, []byte) error,
+) error {
+	num, err := DecodeDynamicLength(buf, maxElements)
+	if err != nil {
+		return err
+	}
+
+	*slice = make([]T, num)
+	return UnmarshalDynamic(buf, num, unmarshalCallback)
+}

--- a/interface.go
+++ b/interface.go
@@ -96,3 +96,27 @@ func UnmarshalDynamicSliceWithCallback[T any](
 	*slice = make([]T, num)
 	return UnmarshalDynamic(buf, num, unmarshalCallback)
 }
+
+func UnmarshalSliceSSZ[T any, PT PtrConstraint[T]](
+	slice *[]PT,
+	buf []byte,
+	itemSize int,
+	maxItems int,
+) error {
+	return UnmarshalSliceWithIndexCallback(slice, buf, itemSize, maxItems,
+		func(ii int, itemBuf []byte) error {
+			return UnmarshalField[T, PT](&(*slice)[ii], itemBuf)
+		})
+}
+
+// UnmarshalDynamicSliceSSZ handles dynamic slices of SSZ types
+func UnmarshalDynamicSliceSSZ[T any, PT PtrConstraint[T]](
+	slice *[]PT,
+	buf []byte,
+	maxElements int,
+) error {
+	return UnmarshalDynamicSliceWithCallback(slice, buf, maxElements,
+		func(indx int, itemBuf []byte) error {
+			return UnmarshalField[T, PT](&(*slice)[indx], itemBuf)
+		})
+}

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -58,12 +58,10 @@ func (a *AggregateAndProof) UnmarshalSSZ(buf []byte) error {
 	copy(a.SelectionProof[:], buf[12:108])
 
 	// Field (1) 'Aggregate'
-	{
-		buf = tail[o1:]
-		if err := ssz.UnmarshalField(&a.Aggregate, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&a.Aggregate, tail[o1:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -143,7 +141,7 @@ func (c *Checkpoint) UnmarshalSSZ(buf []byte) error {
 	c.Epoch = ssz.UnmarshallUint64(buf[0:8])
 
 	// Field (1) 'Root'
-	c.Root = ssz.UnmarshalBytes(c.Root, buf[8:40])
+	c.Root, _ = ssz.UnmarshalBytes(c.Root, buf[8:40])
 
 	return err
 }
@@ -358,16 +356,14 @@ func (a *Attestation) UnmarshalSSZ(buf []byte) error {
 	copy(a.Signature[:], buf[132:228])
 
 	// Field (0) 'AggregationBits'
-	{
-		buf = tail[o0:]
-		if err = ssz.ValidateBitlist(buf, 2048); err != nil {
-			return err
-		}
-		if cap(a.AggregationBits) == 0 {
-			a.AggregationBits = make([]byte, 0, len(buf))
-		}
-		a.AggregationBits = append(a.AggregationBits, buf...)
+	if err = ssz.ValidateBitlist(tail[o0:], 2048); err != nil {
+		return err
 	}
+	if cap(a.AggregationBits) == 0 {
+		a.AggregationBits = make([]byte, 0, len(tail[o0:]))
+	}
+	a.AggregationBits = append(a.AggregationBits, tail[o0:]...)
+
 	return err
 }
 
@@ -463,7 +459,7 @@ func (d *DepositData) UnmarshalSSZ(buf []byte) error {
 	d.Amount = ssz.UnmarshallUint64(buf[80:88])
 
 	// Field (3) 'Signature'
-	d.Signature = ssz.UnmarshalBytes(d.Signature, buf[88:184])
+	d.Signature, _ = ssz.UnmarshalBytes(d.Signature, buf[88:184])
 
 	return err
 }
@@ -552,7 +548,7 @@ func (d *Deposit) UnmarshalSSZ(buf []byte) error {
 	// Field (0) 'Proof'
 	d.Proof = make([][]byte, 33)
 	for ii := 0; ii < 33; ii++ {
-		d.Proof[ii] = ssz.UnmarshalBytes(d.Proof[ii], buf[0:1056][ii*32:(ii+1)*32])
+		d.Proof[ii], _ = ssz.UnmarshalBytes(d.Proof[ii], buf[0:1056][ii*32:(ii+1)*32])
 	}
 
 	// Field (1) 'Data'
@@ -650,10 +646,10 @@ func (d *DepositMessage) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Pubkey'
-	d.Pubkey = ssz.UnmarshalBytes(d.Pubkey, buf[0:48])
+	d.Pubkey, _ = ssz.UnmarshalBytes(d.Pubkey, buf[0:48])
 
 	// Field (1) 'WithdrawalCredentials'
-	d.WithdrawalCredentials = ssz.UnmarshalBytes(d.WithdrawalCredentials, buf[48:80])
+	d.WithdrawalCredentials, _ = ssz.UnmarshalBytes(d.WithdrawalCredentials, buf[48:80])
 
 	// Field (2) 'Amount'
 	d.Amount = ssz.UnmarshallUint64(buf[80:88])
@@ -765,19 +761,16 @@ func (i *IndexedAttestation) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'Signature'
-	i.Signature = ssz.UnmarshalBytes(i.Signature, buf[132:228])
+	i.Signature, _ = ssz.UnmarshalBytes(i.Signature, buf[132:228])
 
 	// Field (0) 'AttestationIndices'
-	{
-		buf = tail[o0:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&i.AttestationIndices, buf, 8, 2048, func(ii int, buf []byte) (err error) {
-			i.AttestationIndices[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&i.AttestationIndices, tail[o0:], 8, 2048, func(ii int, buf []byte) (err error) {
+		i.AttestationIndices[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -905,16 +898,14 @@ func (p *PendingAttestation) UnmarshalSSZ(buf []byte) error {
 	p.ProposerIndex = ssz.UnmarshallUint64(buf[140:148])
 
 	// Field (0) 'AggregationBits'
-	{
-		buf = tail[o0:]
-		if err = ssz.ValidateBitlist(buf, 2048); err != nil {
-			return err
-		}
-		if cap(p.AggregationBits) == 0 {
-			p.AggregationBits = make([]byte, 0, len(buf))
-		}
-		p.AggregationBits = append(p.AggregationBits, buf...)
+	if err = ssz.ValidateBitlist(tail[o0:], 2048); err != nil {
+		return err
 	}
+	if cap(p.AggregationBits) == 0 {
+		p.AggregationBits = make([]byte, 0, len(tail[o0:]))
+	}
+	p.AggregationBits = append(p.AggregationBits, tail[o0:]...)
+
 	return err
 }
 
@@ -1005,10 +996,10 @@ func (f *Fork) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'PreviousVersion'
-	f.PreviousVersion = ssz.UnmarshalBytes(f.PreviousVersion, buf[0:4])
+	f.PreviousVersion, _ = ssz.UnmarshalBytes(f.PreviousVersion, buf[0:4])
 
 	// Field (1) 'CurrentVersion'
-	f.CurrentVersion = ssz.UnmarshalBytes(f.CurrentVersion, buf[4:8])
+	f.CurrentVersion, _ = ssz.UnmarshalBytes(f.CurrentVersion, buf[4:8])
 
 	// Field (2) 'Epoch'
 	f.Epoch = ssz.UnmarshallUint64(buf[8:16])
@@ -1110,10 +1101,10 @@ func (v *Validator) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Pubkey'
-	v.Pubkey = ssz.UnmarshalBytes(v.Pubkey, buf[0:48])
+	v.Pubkey, _ = ssz.UnmarshalBytes(v.Pubkey, buf[0:48])
 
 	// Field (1) 'WithdrawalCredentials'
-	v.WithdrawalCredentials = ssz.UnmarshalBytes(v.WithdrawalCredentials, buf[48:80])
+	v.WithdrawalCredentials, _ = ssz.UnmarshalBytes(v.WithdrawalCredentials, buf[48:80])
 
 	// Field (2) 'EffectiveBalance'
 	v.EffectiveBalance = ssz.UnmarshallUint64(buf[80:88])
@@ -1371,7 +1362,7 @@ func (e *Eth1Block) UnmarshalSSZ(buf []byte) error {
 	e.Timestamp = ssz.UnmarshallUint64(buf[0:8])
 
 	// Field (1) 'DepositRoot'
-	e.DepositRoot = ssz.UnmarshalBytes(e.DepositRoot, buf[8:40])
+	e.DepositRoot, _ = ssz.UnmarshalBytes(e.DepositRoot, buf[8:40])
 
 	// Field (2) 'DepositCount'
 	e.DepositCount = ssz.UnmarshallUint64(buf[40:48])
@@ -1454,13 +1445,13 @@ func (e *Eth1Data) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'DepositRoot'
-	e.DepositRoot = ssz.UnmarshalBytes(e.DepositRoot, buf[0:32])
+	e.DepositRoot, _ = ssz.UnmarshalBytes(e.DepositRoot, buf[0:32])
 
 	// Field (1) 'DepositCount'
 	e.DepositCount = ssz.UnmarshallUint64(buf[32:40])
 
 	// Field (2) 'BlockHash'
-	e.BlockHash = ssz.UnmarshalBytes(e.BlockHash, buf[40:72])
+	e.BlockHash, _ = ssz.UnmarshalBytes(e.BlockHash, buf[40:72])
 
 	return err
 }
@@ -1541,10 +1532,10 @@ func (s *SigningRoot) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'ObjectRoot'
-	s.ObjectRoot = ssz.UnmarshalBytes(s.ObjectRoot, buf[0:32])
+	s.ObjectRoot, _ = ssz.UnmarshalBytes(s.ObjectRoot, buf[0:32])
 
 	// Field (1) 'Domain'
-	s.Domain = ssz.UnmarshalBytes(s.Domain, buf[32:40])
+	s.Domain, _ = ssz.UnmarshalBytes(s.Domain, buf[32:40])
 
 	return err
 }
@@ -1835,20 +1826,15 @@ func (a *AttesterSlashing) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Attestation1'
-	{
-		buf = tail[o0:o1]
-		if err := ssz.UnmarshalField(&a.Attestation1, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&a.Attestation1, tail[o0:o1]); err != nil {
+		return err
 	}
 
 	// Field (1) 'Attestation2'
-	{
-		buf = tail[o1:]
-		if err := ssz.UnmarshalField(&a.Attestation2, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&a.Attestation2, tail[o1:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -1959,10 +1945,10 @@ func (b *BeaconBlock) UnmarshalSSZ(buf []byte) error {
 	b.ProposerIndex = ssz.UnmarshallUint64(buf[8:16])
 
 	// Field (2) 'ParentRoot'
-	b.ParentRoot = ssz.UnmarshalBytes(b.ParentRoot, buf[16:48])
+	b.ParentRoot, _ = ssz.UnmarshalBytes(b.ParentRoot, buf[16:48])
 
 	// Field (3) 'StateRoot'
-	b.StateRoot = ssz.UnmarshalBytes(b.StateRoot, buf[48:80])
+	b.StateRoot, _ = ssz.UnmarshalBytes(b.StateRoot, buf[48:80])
 
 	// Offset (4) 'Body'
 	if o4, err = marker.ReadOffset(buf[80:84]); err != nil {
@@ -1970,12 +1956,10 @@ func (b *BeaconBlock) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'Body'
-	{
-		buf = tail[o4:]
-		if err := ssz.UnmarshalField(&b.Body, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&b.Body, tail[o4:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -2081,15 +2065,13 @@ func (s *SignedBeaconBlock) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (1) 'Signature'
-	s.Signature = ssz.UnmarshalBytes(s.Signature, buf[4:100])
+	s.Signature, _ = ssz.UnmarshalBytes(s.Signature, buf[4:100])
 
 	// Field (0) 'Block'
-	{
-		buf = tail[o0:]
-		if err := ssz.UnmarshalField(&s.Block, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&s.Block, tail[o0:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -2201,10 +2183,10 @@ func (t *Transfer) UnmarshalSSZ(buf []byte) error {
 	t.Slot = ssz.UnmarshallUint64(buf[32:40])
 
 	// Field (5) 'Pubkey'
-	t.Pubkey = ssz.UnmarshalBytes(t.Pubkey, buf[40:88])
+	t.Pubkey, _ = ssz.UnmarshalBytes(t.Pubkey, buf[40:88])
 
 	// Field (6) 'Signature'
-	t.Signature = ssz.UnmarshalBytes(t.Signature, buf[88:184])
+	t.Signature, _ = ssz.UnmarshalBytes(t.Signature, buf[88:184])
 
 	return err
 }
@@ -2516,7 +2498,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
-	b.GenesisValidatorsRoot = ssz.UnmarshalBytes(b.GenesisValidatorsRoot, buf[8:40])
+	b.GenesisValidatorsRoot, _ = ssz.UnmarshalBytes(b.GenesisValidatorsRoot, buf[8:40])
 
 	// Field (2) 'Slot'
 	b.Slot = ssz.UnmarshallUint64(buf[40:48])
@@ -2534,13 +2516,13 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	// Field (5) 'BlockRoots'
 	b.BlockRoots = make([][]byte, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.BlockRoots[ii] = ssz.UnmarshalBytes(b.BlockRoots[ii], buf[176:262320][ii*32:(ii+1)*32])
+		b.BlockRoots[ii], _ = ssz.UnmarshalBytes(b.BlockRoots[ii], buf[176:262320][ii*32:(ii+1)*32])
 	}
 
 	// Field (6) 'StateRoots'
 	b.StateRoots = make([][]byte, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.StateRoots[ii] = ssz.UnmarshalBytes(b.StateRoots[ii], buf[262320:524464][ii*32:(ii+1)*32])
+		b.StateRoots[ii], _ = ssz.UnmarshalBytes(b.StateRoots[ii], buf[262320:524464][ii*32:(ii+1)*32])
 	}
 
 	// Offset (7) 'HistoricalRoots'
@@ -2574,7 +2556,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	// Field (13) 'RandaoMixes'
 	b.RandaoMixes = make([][]byte, 65536)
 	for ii := 0; ii < 65536; ii++ {
-		b.RandaoMixes[ii] = ssz.UnmarshalBytes(b.RandaoMixes[ii], buf[524560:2621712][ii*32:(ii+1)*32])
+		b.RandaoMixes[ii], _ = ssz.UnmarshalBytes(b.RandaoMixes[ii], buf[524560:2621712][ii*32:(ii+1)*32])
 	}
 
 	// Field (14) 'Slashings'
@@ -2594,7 +2576,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (17) 'JustificationBits'
-	b.JustificationBits = ssz.UnmarshalBytes(b.JustificationBits, buf[2687256:2687257])
+	b.JustificationBits, _ = ssz.UnmarshalBytes(b.JustificationBits, buf[2687256:2687257])
 
 	// Field (18) 'PreviousJustifiedCheckpoint'
 	if err := ssz.UnmarshalField(&b.PreviousJustifiedCheckpoint, buf[2687257:2687297]); err != nil {
@@ -2612,84 +2594,41 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (7) 'HistoricalRoots'
-	{
-		buf = tail[o7:o9]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, buf, 32, 16777216, func(ii int, buf []byte) (err error) {
-			b.HistoricalRoots[ii] = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, tail[o7:o9], 32, 16777216, func(ii int, buf []byte) (err error) {
+		b.HistoricalRoots[ii], _ = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (9) 'Eth1DataVotes'
-	{
-		buf = tail[o9:o11]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Eth1DataVotes, buf, 72, 2048, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Eth1DataVotes[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Eth1DataVotes, tail[o9:o11], 72, 2048); err != nil {
+		return err
 	}
 
 	// Field (11) 'Validators'
-	{
-		buf = tail[o11:o12]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Validators, buf, 121, 1099511627776, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Validators[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Validators, tail[o11:o12], 121, 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (12) 'Balances'
-	{
-		buf = tail[o12:o15]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, buf, 8, 1099511627776, func(ii int, buf []byte) (err error) {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, tail[o12:o15], 8, 1099511627776, func(ii int, buf []byte) (err error) {
+		b.Balances[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (15) 'PreviousEpochAttestations'
-	{
-		buf = tail[o15:o16]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.PreviousEpochAttestations, buf, 4096, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.PreviousEpochAttestations[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.PreviousEpochAttestations, tail[o15:o16], 4096); err != nil {
+		return err
 	}
 
 	// Field (16) 'CurrentEpochAttestations'
-	{
-		buf = tail[o16:]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.CurrentEpochAttestations, buf, 4096, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.CurrentEpochAttestations[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.CurrentEpochAttestations, tail[o16:], 4096); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -3112,7 +3051,7 @@ func (b *BeaconBlockBodyPhase0) UnmarshalSSZ(buf []byte) error {
 	marker := ssz.NewOffsetMarker(size, 220)
 
 	// Field (0) 'RandaoReveal'
-	b.RandaoReveal = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
+	b.RandaoReveal, _ = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
 
 	// Field (1) 'Eth1Data'
 	if err := ssz.UnmarshalField(&b.Eth1Data, buf[96:168]); err != nil {
@@ -3148,74 +3087,30 @@ func (b *BeaconBlockBodyPhase0) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (3) 'ProposerSlashings'
-	{
-		buf = tail[o3:o4]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.ProposerSlashings, buf, 416, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.ProposerSlashings[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.ProposerSlashings, tail[o3:o4], 416, 16); err != nil {
+		return err
 	}
 
 	// Field (4) 'AttesterSlashings'
-	{
-		buf = tail[o4:o5]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.AttesterSlashings, buf, 2, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.AttesterSlashings[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.AttesterSlashings, tail[o4:o5], 2); err != nil {
+		return err
 	}
 
 	// Field (5) 'Attestations'
-	{
-		buf = tail[o5:o6]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.Attestations, buf, 128, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Attestations[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.Attestations, tail[o5:o6], 128); err != nil {
+		return err
 	}
 
 	// Field (6) 'Deposits'
-	{
-		buf = tail[o6:o7]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Deposits, buf, 1240, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Deposits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Deposits, tail[o6:o7], 1240, 16); err != nil {
+		return err
 	}
 
 	// Field (7) 'VoluntaryExits'
-	{
-		buf = tail[o7:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.VoluntaryExits, buf, 112, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.VoluntaryExits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.VoluntaryExits, tail[o7:], 112, 16); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -3509,7 +3404,7 @@ func (b *BeaconBlockBodyAltair) UnmarshalSSZ(buf []byte) error {
 	marker := ssz.NewOffsetMarker(size, 380)
 
 	// Field (0) 'RandaoReveal'
-	b.RandaoReveal = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
+	b.RandaoReveal, _ = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
 
 	// Field (1) 'Eth1Data'
 	if err := ssz.UnmarshalField(&b.Eth1Data, buf[96:168]); err != nil {
@@ -3550,74 +3445,30 @@ func (b *BeaconBlockBodyAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (3) 'ProposerSlashings'
-	{
-		buf = tail[o3:o4]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.ProposerSlashings, buf, 416, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.ProposerSlashings[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.ProposerSlashings, tail[o3:o4], 416, 16); err != nil {
+		return err
 	}
 
 	// Field (4) 'AttesterSlashings'
-	{
-		buf = tail[o4:o5]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.AttesterSlashings, buf, 2, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.AttesterSlashings[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.AttesterSlashings, tail[o4:o5], 2); err != nil {
+		return err
 	}
 
 	// Field (5) 'Attestations'
-	{
-		buf = tail[o5:o6]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.Attestations, buf, 128, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Attestations[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.Attestations, tail[o5:o6], 128); err != nil {
+		return err
 	}
 
 	// Field (6) 'Deposits'
-	{
-		buf = tail[o6:o7]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Deposits, buf, 1240, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Deposits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Deposits, tail[o6:o7], 1240, 16); err != nil {
+		return err
 	}
 
 	// Field (7) 'VoluntaryExits'
-	{
-		buf = tail[o7:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.VoluntaryExits, buf, 112, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.VoluntaryExits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.VoluntaryExits, tail[o7:], 112, 16); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -3928,7 +3779,7 @@ func (b *BeaconBlockBodyBellatrix) UnmarshalSSZ(buf []byte) error {
 	marker := ssz.NewOffsetMarker(size, 384)
 
 	// Field (0) 'RandaoReveal'
-	b.RandaoReveal = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
+	b.RandaoReveal, _ = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
 
 	// Field (1) 'Eth1Data'
 	if err := ssz.UnmarshalField(&b.Eth1Data, buf[96:168]); err != nil {
@@ -3974,82 +3825,35 @@ func (b *BeaconBlockBodyBellatrix) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (3) 'ProposerSlashings'
-	{
-		buf = tail[o3:o4]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.ProposerSlashings, buf, 416, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.ProposerSlashings[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.ProposerSlashings, tail[o3:o4], 416, 16); err != nil {
+		return err
 	}
 
 	// Field (4) 'AttesterSlashings'
-	{
-		buf = tail[o4:o5]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.AttesterSlashings, buf, 2, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.AttesterSlashings[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.AttesterSlashings, tail[o4:o5], 2); err != nil {
+		return err
 	}
 
 	// Field (5) 'Attestations'
-	{
-		buf = tail[o5:o6]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.Attestations, buf, 128, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Attestations[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.Attestations, tail[o5:o6], 128); err != nil {
+		return err
 	}
 
 	// Field (6) 'Deposits'
-	{
-		buf = tail[o6:o7]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Deposits, buf, 1240, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Deposits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Deposits, tail[o6:o7], 1240, 16); err != nil {
+		return err
 	}
 
 	// Field (7) 'VoluntaryExits'
-	{
-		buf = tail[o7:o9]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.VoluntaryExits, buf, 112, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.VoluntaryExits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.VoluntaryExits, tail[o7:o9], 112, 16); err != nil {
+		return err
 	}
 
 	// Field (9) 'ExecutionPayload'
-	{
-		buf = tail[o9:]
-		if err := ssz.UnmarshalField(&b.ExecutionPayload, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&b.ExecutionPayload, tail[o9:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -4474,7 +4278,7 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
-	b.GenesisValidatorsRoot = ssz.UnmarshalBytes(b.GenesisValidatorsRoot, buf[8:40])
+	b.GenesisValidatorsRoot, _ = ssz.UnmarshalBytes(b.GenesisValidatorsRoot, buf[8:40])
 
 	// Field (2) 'Slot'
 	b.Slot = ssz.UnmarshallUint64(buf[40:48])
@@ -4492,13 +4296,13 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	// Field (5) 'BlockRoots'
 	b.BlockRoots = make([][]byte, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.BlockRoots[ii] = ssz.UnmarshalBytes(b.BlockRoots[ii], buf[176:262320][ii*32:(ii+1)*32])
+		b.BlockRoots[ii], _ = ssz.UnmarshalBytes(b.BlockRoots[ii], buf[176:262320][ii*32:(ii+1)*32])
 	}
 
 	// Field (6) 'StateRoots'
 	b.StateRoots = make([][]byte, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.StateRoots[ii] = ssz.UnmarshalBytes(b.StateRoots[ii], buf[262320:524464][ii*32:(ii+1)*32])
+		b.StateRoots[ii], _ = ssz.UnmarshalBytes(b.StateRoots[ii], buf[262320:524464][ii*32:(ii+1)*32])
 	}
 
 	// Offset (7) 'HistoricalRoots'
@@ -4532,7 +4336,7 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	// Field (13) 'RandaoMixes'
 	b.RandaoMixes = make([][]byte, 65536)
 	for ii := 0; ii < 65536; ii++ {
-		b.RandaoMixes[ii] = ssz.UnmarshalBytes(b.RandaoMixes[ii], buf[524560:2621712][ii*32:(ii+1)*32])
+		b.RandaoMixes[ii], _ = ssz.UnmarshalBytes(b.RandaoMixes[ii], buf[524560:2621712][ii*32:(ii+1)*32])
 	}
 
 	// Field (14) 'Slashings'
@@ -4552,7 +4356,7 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (17) 'JustificationBits'
-	b.JustificationBits = ssz.UnmarshalBytes(b.JustificationBits, buf[2687256:2687257])
+	b.JustificationBits, _ = ssz.UnmarshalBytes(b.JustificationBits, buf[2687256:2687257])
 
 	// Field (18) 'PreviousJustifiedCheckpoint'
 	if err := ssz.UnmarshalField(&b.PreviousJustifiedCheckpoint, buf[2687257:2687297]); err != nil {
@@ -4585,86 +4389,49 @@ func (b *BeaconStateAltair) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (7) 'HistoricalRoots'
-	{
-		buf = tail[o7:o9]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, buf, 32, 16777216, func(ii int, buf []byte) (err error) {
-			b.HistoricalRoots[ii] = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, tail[o7:o9], 32, 16777216, func(ii int, buf []byte) (err error) {
+		b.HistoricalRoots[ii], _ = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (9) 'Eth1DataVotes'
-	{
-		buf = tail[o9:o11]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Eth1DataVotes, buf, 72, 2048, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Eth1DataVotes[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Eth1DataVotes, tail[o9:o11], 72, 2048); err != nil {
+		return err
 	}
 
 	// Field (11) 'Validators'
-	{
-		buf = tail[o11:o12]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Validators, buf, 121, 1099511627776, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Validators[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Validators, tail[o11:o12], 121, 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (12) 'Balances'
-	{
-		buf = tail[o12:o15]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, buf, 8, 1099511627776, func(ii int, buf []byte) (err error) {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, tail[o12:o15], 8, 1099511627776, func(ii int, buf []byte) (err error) {
+		b.Balances[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
-	{
-		buf = tail[o15:o16]
-		if len(buf) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
-		b.PreviousEpochParticipation = ssz.UnmarshalBytes(b.PreviousEpochParticipation, buf)
+	if b.PreviousEpochParticipation, err = ssz.UnmarshalBytes(b.PreviousEpochParticipation, tail[o15:o16], 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (16) 'CurrentEpochParticipation'
-	{
-		buf = tail[o16:o21]
-		if len(buf) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
-		b.CurrentEpochParticipation = ssz.UnmarshalBytes(b.CurrentEpochParticipation, buf)
+	if b.CurrentEpochParticipation, err = ssz.UnmarshalBytes(b.CurrentEpochParticipation, tail[o16:o21], 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (21) 'InactivityScores'
-	{
-		buf = tail[o21:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.InactivityScores, buf, 8, 1099511627776, func(ii int, buf []byte) (err error) {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.InactivityScores, tail[o21:], 8, 1099511627776, func(ii int, buf []byte) (err error) {
+		b.InactivityScores[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -5236,7 +5003,7 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
-	b.GenesisValidatorsRoot = ssz.UnmarshalBytes(b.GenesisValidatorsRoot, buf[8:40])
+	b.GenesisValidatorsRoot, _ = ssz.UnmarshalBytes(b.GenesisValidatorsRoot, buf[8:40])
 
 	// Field (2) 'Slot'
 	b.Slot = ssz.UnmarshallUint64(buf[40:48])
@@ -5254,13 +5021,13 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	// Field (5) 'BlockRoots'
 	b.BlockRoots = make([][]byte, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.BlockRoots[ii] = ssz.UnmarshalBytes(b.BlockRoots[ii], buf[176:262320][ii*32:(ii+1)*32])
+		b.BlockRoots[ii], _ = ssz.UnmarshalBytes(b.BlockRoots[ii], buf[176:262320][ii*32:(ii+1)*32])
 	}
 
 	// Field (6) 'StateRoots'
 	b.StateRoots = make([][]byte, 8192)
 	for ii := 0; ii < 8192; ii++ {
-		b.StateRoots[ii] = ssz.UnmarshalBytes(b.StateRoots[ii], buf[262320:524464][ii*32:(ii+1)*32])
+		b.StateRoots[ii], _ = ssz.UnmarshalBytes(b.StateRoots[ii], buf[262320:524464][ii*32:(ii+1)*32])
 	}
 
 	// Offset (7) 'HistoricalRoots'
@@ -5294,7 +5061,7 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	// Field (13) 'RandaoMixes'
 	b.RandaoMixes = make([][]byte, 65536)
 	for ii := 0; ii < 65536; ii++ {
-		b.RandaoMixes[ii] = ssz.UnmarshalBytes(b.RandaoMixes[ii], buf[524560:2621712][ii*32:(ii+1)*32])
+		b.RandaoMixes[ii], _ = ssz.UnmarshalBytes(b.RandaoMixes[ii], buf[524560:2621712][ii*32:(ii+1)*32])
 	}
 
 	// Field (14) 'Slashings'
@@ -5314,7 +5081,7 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (17) 'JustificationBits'
-	b.JustificationBits = ssz.UnmarshalBytes(b.JustificationBits, buf[2687256:2687257])
+	b.JustificationBits, _ = ssz.UnmarshalBytes(b.JustificationBits, buf[2687256:2687257])
 
 	// Field (18) 'PreviousJustifiedCheckpoint'
 	if err := ssz.UnmarshalField(&b.PreviousJustifiedCheckpoint, buf[2687257:2687297]); err != nil {
@@ -5352,94 +5119,54 @@ func (b *BeaconStateBellatrix) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (7) 'HistoricalRoots'
-	{
-		buf = tail[o7:o9]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, buf, 32, 16777216, func(ii int, buf []byte) (err error) {
-			b.HistoricalRoots[ii] = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, tail[o7:o9], 32, 16777216, func(ii int, buf []byte) (err error) {
+		b.HistoricalRoots[ii], _ = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (9) 'Eth1DataVotes'
-	{
-		buf = tail[o9:o11]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Eth1DataVotes, buf, 72, 2048, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Eth1DataVotes[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Eth1DataVotes, tail[o9:o11], 72, 2048); err != nil {
+		return err
 	}
 
 	// Field (11) 'Validators'
-	{
-		buf = tail[o11:o12]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Validators, buf, 121, 1099511627776, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Validators[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Validators, tail[o11:o12], 121, 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (12) 'Balances'
-	{
-		buf = tail[o12:o15]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, buf, 8, 1099511627776, func(ii int, buf []byte) (err error) {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, tail[o12:o15], 8, 1099511627776, func(ii int, buf []byte) (err error) {
+		b.Balances[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
-	{
-		buf = tail[o15:o16]
-		if len(buf) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
-		b.PreviousEpochParticipation = ssz.UnmarshalBytes(b.PreviousEpochParticipation, buf)
+	if b.PreviousEpochParticipation, err = ssz.UnmarshalBytes(b.PreviousEpochParticipation, tail[o15:o16], 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (16) 'CurrentEpochParticipation'
-	{
-		buf = tail[o16:o21]
-		if len(buf) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
-		b.CurrentEpochParticipation = ssz.UnmarshalBytes(b.CurrentEpochParticipation, buf)
+	if b.CurrentEpochParticipation, err = ssz.UnmarshalBytes(b.CurrentEpochParticipation, tail[o16:o21], 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (21) 'InactivityScores'
-	{
-		buf = tail[o21:o24]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.InactivityScores, buf, 8, 1099511627776, func(ii int, buf []byte) (err error) {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.InactivityScores, tail[o21:o24], 8, 1099511627776, func(ii int, buf []byte) (err error) {
+		b.InactivityScores[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (24) 'LatestExecutionPayloadHeader'
-	{
-		buf = tail[o24:]
-		if err := ssz.UnmarshalField(&b.LatestExecutionPayloadHeader, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&b.LatestExecutionPayloadHeader, tail[o24:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -5796,7 +5523,7 @@ func (s *SignedBeaconBlockHeader) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (1) 'Signature'
-	s.Signature = ssz.UnmarshalBytes(s.Signature, buf[112:208])
+	s.Signature, _ = ssz.UnmarshalBytes(s.Signature, buf[112:208])
 
 	return err
 }
@@ -5894,13 +5621,13 @@ func (b *BeaconBlockHeader) UnmarshalSSZ(buf []byte) error {
 	b.ProposerIndex = ssz.UnmarshallUint64(buf[8:16])
 
 	// Field (2) 'ParentRoot'
-	b.ParentRoot = ssz.UnmarshalBytes(b.ParentRoot, buf[16:48])
+	b.ParentRoot, _ = ssz.UnmarshalBytes(b.ParentRoot, buf[16:48])
 
 	// Field (3) 'StateRoot'
-	b.StateRoot = ssz.UnmarshalBytes(b.StateRoot, buf[48:80])
+	b.StateRoot, _ = ssz.UnmarshalBytes(b.StateRoot, buf[48:80])
 
 	// Field (4) 'BodyRoot'
-	b.BodyRoot = ssz.UnmarshalBytes(b.BodyRoot, buf[80:112])
+	b.BodyRoot, _ = ssz.UnmarshalBytes(b.BodyRoot, buf[80:112])
 
 	return err
 }
@@ -5997,13 +5724,10 @@ func (e *ErrorResponse) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Message'
-	{
-		buf = tail[o0:]
-		if len(buf) > 256 {
-			return ssz.ErrBytesLength
-		}
-		e.Message = ssz.UnmarshalBytes(e.Message, buf)
+	if e.Message, err = ssz.UnmarshalBytes(e.Message, tail[o0:], 256); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -6133,7 +5857,7 @@ func (s *SyncCommittee) UnmarshalSSZ(buf []byte) error {
 	// Field (0) 'PubKeys'
 	s.PubKeys = make([][]byte, 512)
 	for ii := 0; ii < 512; ii++ {
-		s.PubKeys[ii] = ssz.UnmarshalBytes(s.PubKeys[ii], buf[0:24576][ii*48:(ii+1)*48])
+		s.PubKeys[ii], _ = ssz.UnmarshalBytes(s.PubKeys[ii], buf[0:24576][ii*48:(ii+1)*48])
 	}
 
 	// Field (1) 'AggregatePubKey'
@@ -6217,7 +5941,7 @@ func (s *SyncAggregate) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'SyncCommiteeBits'
-	s.SyncCommiteeBits = ssz.UnmarshalBytes(s.SyncCommiteeBits, buf[0:64])
+	s.SyncCommiteeBits, _ = ssz.UnmarshalBytes(s.SyncCommiteeBits, buf[0:64])
 
 	// Field (1) 'SyncCommiteeSignature'
 	copy(s.SyncCommiteeSignature[:], buf[64:160])
@@ -6401,28 +6125,20 @@ func (e *ExecutionPayload) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'ExtraData'
-	{
-		buf = tail[o10:o13]
-		if len(buf) > 32 {
-			return ssz.ErrBytesLength
-		}
-		e.ExtraData = ssz.UnmarshalBytes(e.ExtraData, buf)
+	if e.ExtraData, err = ssz.UnmarshalBytes(e.ExtraData, tail[o10:o13], 32); err != nil {
+		return err
 	}
 
 	// Field (13) 'Transactions'
-	{
-		buf = tail[o13:]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, buf, 1048576, func(indx int, buf []byte) (err error) {
-			if len(buf) > 1073741824 {
-				return ssz.ErrBytesLength
-			}
-			e.Transactions[indx] = ssz.UnmarshalBytes(e.Transactions[indx], buf)
-			return nil
-		})
-		if err != nil {
+	if err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, tail[o13:], 1048576, func(indx int, buf []byte) (err error) {
+		if e.Transactions[indx], err = ssz.UnmarshalBytes(e.Transactions[indx], buf, 1073741824); err != nil {
 			return err
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -6642,22 +6358,22 @@ func (e *ExecutionPayloadHeader) UnmarshalSSZ(buf []byte) error {
 	marker := ssz.NewOffsetMarker(size, 536)
 
 	// Field (0) 'ParentHash'
-	e.ParentHash = ssz.UnmarshalBytes(e.ParentHash, buf[0:32])
+	e.ParentHash, _ = ssz.UnmarshalBytes(e.ParentHash, buf[0:32])
 
 	// Field (1) 'FeeRecipient'
-	e.FeeRecipient = ssz.UnmarshalBytes(e.FeeRecipient, buf[32:52])
+	e.FeeRecipient, _ = ssz.UnmarshalBytes(e.FeeRecipient, buf[32:52])
 
 	// Field (2) 'StateRoot'
-	e.StateRoot = ssz.UnmarshalBytes(e.StateRoot, buf[52:84])
+	e.StateRoot, _ = ssz.UnmarshalBytes(e.StateRoot, buf[52:84])
 
 	// Field (3) 'ReceiptsRoot'
-	e.ReceiptsRoot = ssz.UnmarshalBytes(e.ReceiptsRoot, buf[84:116])
+	e.ReceiptsRoot, _ = ssz.UnmarshalBytes(e.ReceiptsRoot, buf[84:116])
 
 	// Field (4) 'LogsBloom'
-	e.LogsBloom = ssz.UnmarshalBytes(e.LogsBloom, buf[116:372])
+	e.LogsBloom, _ = ssz.UnmarshalBytes(e.LogsBloom, buf[116:372])
 
 	// Field (5) 'PrevRandao'
-	e.PrevRandao = ssz.UnmarshalBytes(e.PrevRandao, buf[372:404])
+	e.PrevRandao, _ = ssz.UnmarshalBytes(e.PrevRandao, buf[372:404])
 
 	// Field (6) 'BlockNumber'
 	e.BlockNumber = ssz.UnmarshallUint64(buf[404:412])
@@ -6677,22 +6393,19 @@ func (e *ExecutionPayloadHeader) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (11) 'BaseFeePerGas'
-	e.BaseFeePerGas = ssz.UnmarshalBytes(e.BaseFeePerGas, buf[440:472])
+	e.BaseFeePerGas, _ = ssz.UnmarshalBytes(e.BaseFeePerGas, buf[440:472])
 
 	// Field (12) 'BlockHash'
-	e.BlockHash = ssz.UnmarshalBytes(e.BlockHash, buf[472:504])
+	e.BlockHash, _ = ssz.UnmarshalBytes(e.BlockHash, buf[472:504])
 
 	// Field (13) 'TransactionsRoot'
-	e.TransactionsRoot = ssz.UnmarshalBytes(e.TransactionsRoot, buf[504:536])
+	e.TransactionsRoot, _ = ssz.UnmarshalBytes(e.TransactionsRoot, buf[504:536])
 
 	// Field (10) 'ExtraData'
-	{
-		buf = tail[o10:]
-		if len(buf) > 32 {
-			return ssz.ErrBytesLength
-		}
-		e.ExtraData = ssz.UnmarshalBytes(e.ExtraData, buf)
+	if e.ExtraData, err = ssz.UnmarshalBytes(e.ExtraData, tail[o10:], 32); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -6865,19 +6578,15 @@ func (e *ExecutionPayloadTransactions) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Transactions'
-	{
-		buf = tail[o0:]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, buf, 1048576, func(indx int, buf []byte) (err error) {
-			if len(buf) > 1073741824 {
-				return ssz.ErrBytesLength
-			}
-			e.Transactions[indx] = ssz.UnmarshalBytes(e.Transactions[indx], buf)
-			return nil
-		})
-		if err != nil {
+	if err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, tail[o0:], 1048576, func(indx int, buf []byte) (err error) {
+		if e.Transactions[indx], err = ssz.UnmarshalBytes(e.Transactions[indx], buf, 1073741824); err != nil {
 			return err
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -7100,42 +6809,25 @@ func (e *ExecutionPayloadCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'ExtraData'
-	{
-		buf = tail[o10:o13]
-		if len(buf) > 32 {
-			return ssz.ErrBytesLength
-		}
-		e.ExtraData = ssz.UnmarshalBytes(e.ExtraData, buf)
+	if e.ExtraData, err = ssz.UnmarshalBytes(e.ExtraData, tail[o10:o13], 32); err != nil {
+		return err
 	}
 
 	// Field (13) 'Transactions'
-	{
-		buf = tail[o13:o14]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, buf, 1048576, func(indx int, buf []byte) (err error) {
-			if len(buf) > 1073741824 {
-				return ssz.ErrBytesLength
-			}
-			e.Transactions[indx] = ssz.UnmarshalBytes(e.Transactions[indx], buf)
-			return nil
-		})
-		if err != nil {
+	if err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, tail[o13:o14], 1048576, func(indx int, buf []byte) (err error) {
+		if e.Transactions[indx], err = ssz.UnmarshalBytes(e.Transactions[indx], buf, 1073741824); err != nil {
 			return err
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (14) 'Withdrawals'
-	{
-		buf = tail[o14:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&e.Withdrawals, buf, 44, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&e.Withdrawals[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&e.Withdrawals, tail[o14:], 44, 16); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -7388,13 +7080,10 @@ func (e *ExecutionPayloadHeaderCapella) UnmarshalSSZ(buf []byte) error {
 	copy(e.WithdrawalRoot[:], buf[536:568])
 
 	// Field (10) 'ExtraData'
-	{
-		buf = tail[o10:]
-		if len(buf) > 32 {
-			return ssz.ErrBytesLength
-		}
-		e.ExtraData = ssz.UnmarshalBytes(e.ExtraData, buf)
+	if e.ExtraData, err = ssz.UnmarshalBytes(e.ExtraData, tail[o10:], 32); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -8165,108 +7854,59 @@ func (b *BeaconStateCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (7) 'HistoricalRoots'
-	{
-		buf = tail[o7:o9]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, buf, 32, 16777216, func(ii int, buf []byte) (err error) {
-			b.HistoricalRoots[ii] = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalRoots, tail[o7:o9], 32, 16777216, func(ii int, buf []byte) (err error) {
+		b.HistoricalRoots[ii], _ = ssz.UnmarshalBytes(b.HistoricalRoots[ii], buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (9) 'Eth1DataVotes'
-	{
-		buf = tail[o9:o11]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Eth1DataVotes, buf, 72, 2048, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Eth1DataVotes[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Eth1DataVotes, tail[o9:o11], 72, 2048); err != nil {
+		return err
 	}
 
 	// Field (11) 'Validators'
-	{
-		buf = tail[o11:o12]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Validators, buf, 121, 1099511627776, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Validators[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Validators, tail[o11:o12], 121, 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (12) 'Balances'
-	{
-		buf = tail[o12:o15]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, buf, 8, 1099511627776, func(ii int, buf []byte) (err error) {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.Balances, tail[o12:o15], 8, 1099511627776, func(ii int, buf []byte) (err error) {
+		b.Balances[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
-	{
-		buf = tail[o15:o16]
-		if len(buf) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
-		b.PreviousEpochParticipation = ssz.UnmarshalBytes(b.PreviousEpochParticipation, buf)
+	if b.PreviousEpochParticipation, err = ssz.UnmarshalBytes(b.PreviousEpochParticipation, tail[o15:o16], 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (16) 'CurrentEpochParticipation'
-	{
-		buf = tail[o16:o21]
-		if len(buf) > 1099511627776 {
-			return ssz.ErrBytesLength
-		}
-		b.CurrentEpochParticipation = ssz.UnmarshalBytes(b.CurrentEpochParticipation, buf)
+	if b.CurrentEpochParticipation, err = ssz.UnmarshalBytes(b.CurrentEpochParticipation, tail[o16:o21], 1099511627776); err != nil {
+		return err
 	}
 
 	// Field (21) 'InactivityScores'
-	{
-		buf = tail[o21:o24]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.InactivityScores, buf, 8, 1099511627776, func(ii int, buf []byte) (err error) {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&b.InactivityScores, tail[o21:o24], 8, 1099511627776, func(ii int, buf []byte) (err error) {
+		b.InactivityScores[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (24) 'LatestExecutionPayloadHeader'
-	{
-		buf = tail[o24:o27]
-		if err := ssz.UnmarshalField(&b.LatestExecutionPayloadHeader, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&b.LatestExecutionPayloadHeader, tail[o24:o27]); err != nil {
+		return err
 	}
 
 	// Field (27) 'HistoricalSummaries'
-	{
-		buf = tail[o27:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.HistoricalSummaries, buf, 64, 16777216, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.HistoricalSummaries[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.HistoricalSummaries, tail[o27:], 64, 16777216); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -8621,15 +8261,13 @@ func (s *SignedBeaconBlockCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (1) 'Signature'
-	s.Signature = ssz.UnmarshalBytes(s.Signature, buf[4:100])
+	s.Signature, _ = ssz.UnmarshalBytes(s.Signature, buf[4:100])
 
 	// Field (0) 'Block'
-	{
-		buf = tail[o0:]
-		if err := ssz.UnmarshalField(&s.Block, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&s.Block, tail[o0:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -8739,12 +8377,10 @@ func (b *BeaconBlockCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'Body'
-	{
-		buf = tail[o4:]
-		if err := ssz.UnmarshalField(&b.Body, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&b.Body, tail[o4:]); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -8969,7 +8605,7 @@ func (b *BeaconBlockBodyCapella) UnmarshalSSZ(buf []byte) error {
 	marker := ssz.NewOffsetMarker(size, 388)
 
 	// Field (0) 'RandaoReveal'
-	b.RandaoReveal = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
+	b.RandaoReveal, _ = ssz.UnmarshalBytes(b.RandaoReveal, buf[0:96])
 
 	// Field (1) 'Eth1Data'
 	if err := ssz.UnmarshalField(&b.Eth1Data, buf[96:168]); err != nil {
@@ -9020,96 +8656,40 @@ func (b *BeaconBlockBodyCapella) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (3) 'ProposerSlashings'
-	{
-		buf = tail[o3:o4]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.ProposerSlashings, buf, 416, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.ProposerSlashings[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.ProposerSlashings, tail[o3:o4], 416, 16); err != nil {
+		return err
 	}
 
 	// Field (4) 'AttesterSlashings'
-	{
-		buf = tail[o4:o5]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.AttesterSlashings, buf, 2, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.AttesterSlashings[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.AttesterSlashings, tail[o4:o5], 2); err != nil {
+		return err
 	}
 
 	// Field (5) 'Attestations'
-	{
-		buf = tail[o5:o6]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&b.Attestations, buf, 128, func(indx int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Attestations[indx], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalDynamicSliceSSZ(&b.Attestations, tail[o5:o6], 128); err != nil {
+		return err
 	}
 
 	// Field (6) 'Deposits'
-	{
-		buf = tail[o6:o7]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.Deposits, buf, 1240, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.Deposits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.Deposits, tail[o6:o7], 1240, 16); err != nil {
+		return err
 	}
 
 	// Field (7) 'VoluntaryExits'
-	{
-		buf = tail[o7:o9]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.VoluntaryExits, buf, 112, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.VoluntaryExits[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.VoluntaryExits, tail[o7:o9], 112, 16); err != nil {
+		return err
 	}
 
 	// Field (9) 'ExecutionPayload'
-	{
-		buf = tail[o9:o10]
-		if err := ssz.UnmarshalField(&b.ExecutionPayload, buf); err != nil {
-			return err
-		}
+	if err := ssz.UnmarshalField(&b.ExecutionPayload, tail[o9:o10]); err != nil {
+		return err
 	}
 
 	// Field (10) 'BlsToExecutionChanges'
-	{
-		buf = tail[o10:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&b.BlsToExecutionChanges, buf, 172, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&b.BlsToExecutionChanges[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&b.BlsToExecutionChanges, tail[o10:], 172, 16); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -9472,42 +9052,25 @@ func (e *ExecutionPayloadDeneb) UnmarshalSSZ(buf []byte) error {
 	e.ExcessBlobGas = ssz.UnmarshallUint64(buf[520:528])
 
 	// Field (10) 'ExtraData'
-	{
-		buf = tail[o10:o13]
-		if len(buf) > 32 {
-			return ssz.ErrBytesLength
-		}
-		e.ExtraData = ssz.UnmarshalBytes(e.ExtraData, buf)
+	if e.ExtraData, err = ssz.UnmarshalBytes(e.ExtraData, tail[o10:o13], 32); err != nil {
+		return err
 	}
 
 	// Field (13) 'Transactions'
-	{
-		buf = tail[o13:o14]
-		err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, buf, 1048576, func(indx int, buf []byte) (err error) {
-			if len(buf) > 1073741824 {
-				return ssz.ErrBytesLength
-			}
-			e.Transactions[indx] = ssz.UnmarshalBytes(e.Transactions[indx], buf)
-			return nil
-		})
-		if err != nil {
+	if err = ssz.UnmarshalDynamicSliceWithCallback(&e.Transactions, tail[o13:o14], 1048576, func(indx int, buf []byte) (err error) {
+		if e.Transactions[indx], err = ssz.UnmarshalBytes(e.Transactions[indx], buf, 1073741824); err != nil {
 			return err
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (14) 'Withdrawals'
-	{
-		buf = tail[o14:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&e.Withdrawals, buf, 44, 16, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&e.Withdrawals[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&e.Withdrawals, tail[o14:], 44, 16); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -9778,13 +9341,10 @@ func (e *ExecutionPayloadHeaderDeneb) UnmarshalSSZ(buf []byte) error {
 	e.ExcessBlobGas = ssz.UnmarshallUint64(buf[576:584])
 
 	// Field (10) 'ExtraData'
-	{
-		buf = tail[o10:]
-		if len(buf) > 32 {
-			return ssz.ErrBytesLength
-		}
-		e.ExtraData = ssz.UnmarshalBytes(e.ExtraData, buf)
+	if e.ExtraData, err = ssz.UnmarshalBytes(e.ExtraData, tail[o10:], 32); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/generator/generator.go
+++ b/sszgen/generator/generator.go
@@ -30,7 +30,7 @@ const bytesPerLengthOffset = 4
 // using the Value object.
 // 3. Use the IR to print the encoding functions
 
-func Encode(source string, targets []string, output string, includePaths []string, excludeTypeNames map[string]bool, suffix string) error {
+func Encode(source string, targets []string, output string, includePaths []string, excludeTypeNames map[string]bool, suffix string, doFormat bool) error {
 	files, err := parseInput(source) // 1.
 	if err != nil {
 		return err
@@ -88,9 +88,11 @@ func Encode(source string, targets []string, output string, includePaths []strin
 	for name, str := range out {
 		output := []byte(str)
 
-		output, err = format.Source(output)
-		if err != nil {
-			return err
+		if doFormat {
+			output, err = format.Source(output)
+			if err != nil {
+				return err
+			}
 		}
 		if err := ioutil.WriteFile(name, output, 0o644); err != nil {
 			return err

--- a/sszgen/generator/ir.go
+++ b/sszgen/generator/ir.go
@@ -97,6 +97,13 @@ func (v *Value) getObjs() []*Value {
 	return nil
 }
 
+func (v *Value) isContainer() bool {
+	if _, ok := v.typ.(*Container); ok {
+		return true
+	}
+	return false
+}
+
 func (v *Value) Type() string {
 	switch v.typ.(type) {
 	case *Bool:

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -32,22 +32,24 @@ func (v *Value) unmarshal(dst string) string {
 		if !obj.IsList && !obj.IsGoDyn {
 			return fmt.Sprintf("copy(::.%s[:], %s)", v.name, dst)
 		}
-		validate := ""
-		if !v.isFixed() {
-			// dynamic bytes, we need to validate the size of the buffer
-			validate = fmt.Sprintf("if len(%s) > %d { return ssz.ErrBytesLength }\n", dst, obj.Size)
-		}
 
 		// both fixed and dynamic are decoded equally
-		tmpl := `{{.validate}}::.{{.name}} = ssz.UnmarshalBytes(::.{{.name}}, {{.dst}})`
+		var tmpl string
+		if !v.isFixed() {
+			// dynamic bytes, we need to validate the size of the buffer
+			tmpl = `if ::.{{.name}}, err = ssz.UnmarshalBytes(::.{{.name}}, {{.dst}}, {{.size}}); err != nil {
+			return err
+			}`
+		} else {
+			tmpl = `::.{{.name}}, _ = ssz.UnmarshalBytes(::.{{.name}}, {{.dst}})`
+		}
 
 		return execTmpl(tmpl, map[string]interface{}{
-			"validate": validate,
-			"name":     v.name,
-			"dst":      dst,
-			"size":     obj.Size,
-			"isRef":    v.ref != "",
-			"obj":      v,
+			"name":  v.name,
+			"dst":   dst,
+			"size":  obj.Size,
+			"isRef": v.ref != "",
+			"obj":   v,
 		})
 
 	case *BitList:
@@ -95,18 +97,18 @@ func (v *Value) unmarshal(dst string) string {
 				"unmarshal": obj.Elem.unmarshal(dst),
 			})
 		} else {
-			return v.unmarshalList()
+			return v.unmarshalList(dst)
 		}
 
 	case *List:
-		return v.unmarshalList()
+		return v.unmarshalList(dst)
 
 	default:
 		panic(fmt.Errorf("unmarshal not implemented for type %s", v.Type()))
 	}
 }
 
-func (v *Value) unmarshalList() string {
+func (v *Value) unmarshalList(dst string) string {
 	var size uint64
 	if obj, ok := v.typ.(*List); ok {
 		size = obj.MaxSize
@@ -118,31 +120,45 @@ func (v *Value) unmarshalList() string {
 
 	inner := getElem(v.typ)
 	if inner.isFixed() {
-		tmpl := `err = ssz.UnmarshalSliceWithIndexCallback(&::.{{.name}}, buf, {{.size}}, {{.max}}, func(ii int, buf []byte) (err error) {
-			{{.unmarshal}}
-			return nil
-		})
-		if err != nil {
+		var tmpl string
+		if inner.isContainer() {
+			tmpl = `if err = ssz.UnmarshalSliceSSZ(&::.{{.name}}, {{.dst}}, {{.size}}, {{.max}}); err != nil {
 			return err
 		}`
+		} else {
+			tmpl = `if err = ssz.UnmarshalSliceWithIndexCallback(&::.{{.name}}, {{.dst}}, {{.size}}, {{.max}}, func(ii int, buf []byte) (err error) {
+			{{.unmarshal}}
+			return nil
+		}); err != nil {
+			return err
+		}`
+		}
 		return execTmpl(tmpl, map[string]interface{}{
 			"size":      inner.fixedSize(),
 			"max":       size,
 			"name":      v.name,
 			"unmarshal": inner.unmarshal("buf"),
+			"dst":       dst,
 		})
 	}
 
 	// Decode list with a dynamic element. 'ssz.DecodeDynamicLength' ensures
 	// that the number of elements do not surpass the 'ssz-max' tag.
 
-	tmpl := `err = ssz.UnmarshalDynamicSliceWithCallback(&::.{{.name}}, buf, {{.max}}, func(indx int, buf []byte) (err error) {
+	var tmpl string
+
+	if inner.isContainer() {
+		tmpl = `if err = ssz.UnmarshalDynamicSliceSSZ(&::.{{.name}}, {{.dst}}, {{.max}}); err != nil {
+			return err
+		}`
+	} else {
+		tmpl = `if err = ssz.UnmarshalDynamicSliceWithCallback(&::.{{.name}}, {{.dst}}, {{.max}}, func(indx int, buf []byte) (err error) {
 		{{.unmarshal}}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}`
+	}
 
 	inner.name = v.name + "[indx]"
 
@@ -151,6 +167,7 @@ func (v *Value) unmarshalList() string {
 		"name":      v.name,
 		"create":    v.createSlice(true),
 		"unmarshal": inner.unmarshal("buf"),
+		"dst":       dst,
 	}
 	return execTmpl(tmpl, data)
 }
@@ -290,17 +307,17 @@ func (v *Value) umarshalContainer(start bool, dst string) (str string) {
 			} else {
 				to = offsets[c+1]
 			}
+			dst := fmt.Sprintf("tail[%s:%s]", from, to)
 			tmpl := `// Field ({{.indx}}) '{{.name}}'
-			{
-				buf = tail[{{.from}}:{{.to}}]
-				{{.unmarshal}}
-			}`
+			{{.unmarshal}}
+			`
+
 			res := execTmpl(tmpl, map[string]interface{}{
 				"indx":      indx,
 				"name":      i.name,
 				"from":      from,
 				"to":        to,
-				"unmarshal": i.unmarshal("buf"),
+				"unmarshal": i.unmarshal(dst),
 			})
 			outs = append(outs, res)
 			c++

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -121,7 +121,7 @@ func (v *Value) unmarshalList(dst string) string {
 	inner := getElem(v.typ)
 	if inner.isFixed() {
 		var tmpl string
-		if inner.isContainer() {
+		if inner.isContainer() && !inner.noPtr {
 			tmpl = `if err = ssz.UnmarshalSliceSSZ(&::.{{.name}}, {{.dst}}, {{.size}}, {{.max}}); err != nil {
 			return err
 		}`
@@ -147,7 +147,7 @@ func (v *Value) unmarshalList(dst string) string {
 
 	var tmpl string
 
-	if inner.isContainer() {
+	if inner.isContainer() && !inner.noPtr {
 		tmpl = `if err = ssz.UnmarshalDynamicSliceSSZ(&::.{{.name}}, {{.dst}}, {{.max}}); err != nil {
 			return err
 		}`

--- a/sszgen/main.go
+++ b/sszgen/main.go
@@ -32,6 +32,7 @@ func generate() {
 	var include string
 	var excludeObjs string
 	var suffix string
+	var noFormat bool
 
 	flag.StringVar(&source, "path", "", "")
 	flag.StringVar(&objsStr, "objs", "", "")
@@ -39,6 +40,7 @@ func generate() {
 	flag.StringVar(&output, "output", "", "")
 	flag.StringVar(&include, "include", "", "")
 	flag.StringVar(&suffix, "suffix", "encoding", "")
+	flag.BoolVar(&noFormat, "no-format", false, "Do not format output files with gofmt")
 
 	flag.Parse()
 
@@ -56,7 +58,7 @@ func generate() {
 		suffix = fmt.Sprintf("%s.go", suffix)
 	}
 
-	if err := generator.Encode(source, targets, output, includeList, excludeTypeNames, suffix); err != nil {
+	if err := generator.Encode(source, targets, output, includeList, excludeTypeNames, suffix, !noFormat); err != nil {
 		fmt.Printf("[ERR]: %v\n", err)
 		os.Exit(1)
 	}

--- a/sszgen/testcases/case1_encoding.go
+++ b/sszgen/testcases/case1_encoding.go
@@ -48,13 +48,10 @@ func (c *Case1A) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Foo'
-	{
-		buf = tail[o0:]
-		if len(buf) > 2048 {
-			return ssz.ErrBytesLength
-		}
-		c.Foo = ssz.UnmarshalBytes(c.Foo, buf)
+	if c.Foo, err = ssz.UnmarshalBytes(c.Foo, tail[o0:], 2048); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -139,13 +136,10 @@ func (c *Case1B) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Bar'
-	{
-		buf = tail[o0:]
-		if len(buf) > 32 {
-			return ssz.ErrBytesLength
-		}
-		c.Bar = ssz.UnmarshalBytes(c.Bar, buf)
+	if c.Bar, err = ssz.UnmarshalBytes(c.Bar, tail[o0:], 32); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/testcases/case4_encoding.go
+++ b/sszgen/testcases/case4_encoding.go
@@ -69,7 +69,7 @@ func (c *Case4) UnmarshalSSZ(buf []byte) error {
 	c.C = alias.Case4Slot(ssz.UnmarshallUint64(buf[192:200]))
 
 	// Field (3) 'D'
-	c.D = ssz.UnmarshalBytes(c.D, buf[200:296])
+	c.D, _ = ssz.UnmarshalBytes(c.D, buf[200:296])
 
 	// Field (4) 'E'
 	copy(c.E[:], buf[296:392])

--- a/sszgen/testcases/case5_encoding.go
+++ b/sszgen/testcases/case5_encoding.go
@@ -69,19 +69,19 @@ func (c *Case5A) UnmarshalSSZ(buf []byte) error {
 	// Field (0) 'A'
 	c.A = make([][]byte, 2)
 	for ii := 0; ii < 2; ii++ {
-		c.A[ii] = ssz.UnmarshalBytes(c.A[ii], buf[0:4][ii*2:(ii+1)*2])
+		c.A[ii], _ = ssz.UnmarshalBytes(c.A[ii], buf[0:4][ii*2:(ii+1)*2])
 	}
 
 	// Field (1) 'B'
 	c.B = make([]Case5Bytes, 2)
 	for ii := 0; ii < 2; ii++ {
-		c.B[ii] = ssz.UnmarshalBytes(c.B[ii], buf[4:8][ii*2:(ii+1)*2])
+		c.B[ii], _ = ssz.UnmarshalBytes(c.B[ii], buf[4:8][ii*2:(ii+1)*2])
 	}
 
 	// Field (2) 'C'
 	c.C = make([][]byte, 2)
 	for ii := 0; ii < 2; ii++ {
-		c.C[ii] = ssz.UnmarshalBytes(c.C[ii], buf[8:12][ii*2:(ii+1)*2])
+		c.C[ii], _ = ssz.UnmarshalBytes(c.C[ii], buf[8:12][ii*2:(ii+1)*2])
 	}
 
 	return err

--- a/sszgen/testcases/case7_encoding.go
+++ b/sszgen/testcases/case7_encoding.go
@@ -54,17 +54,13 @@ func (c *Case7) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'BlobKzgs'
-	{
-		buf = tail[o0:]
-		num, err := ssz.DivideInt2(len(buf), 48, 16)
-		if err != nil {
-			return err
-		}
-		c.BlobKzgs = make([][]byte, num)
-		for ii := 0; ii < num; ii++ {
-			c.BlobKzgs[ii] = ssz.UnmarshalBytes(c.BlobKzgs[ii], buf[ii*48:(ii+1)*48])
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&c.BlobKzgs, tail[o0:], 48, 16, func(ii int, buf []byte) (err error) {
+		c.BlobKzgs[ii], _ = ssz.UnmarshalBytes(c.BlobKzgs[ii], buf)
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/testcases/container_encoding.go
+++ b/sszgen/testcases/container_encoding.go
@@ -125,17 +125,13 @@ func (v *Vec2) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Values2'
-	{
-		buf = tail[o0:]
-		num, err := ssz.DivideInt2(len(buf), 4, 100)
-		if err != nil {
-			return err
-		}
-		v.Values2 = ssz.ExtendUint32(v.Values2, num)
-		for ii := 0; ii < num; ii++ {
-			v.Values2[ii] = ssz.UnmarshallUint32(buf[ii*4 : (ii+1)*4])
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&v.Values2, tail[o0:], 4, 100, func(ii int, buf []byte) (err error) {
+		v.Values2[ii] = ssz.UnmarshallUint32(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/testcases/integration_uint_encoding.go
+++ b/sszgen/testcases/integration_uint_encoding.go
@@ -128,56 +128,37 @@ func (i *IntegrationUint) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (4) 'A1'
-	{
-		buf = tail[o4:o5]
-		num, err := ssz.DivideInt2(len(buf), 1, 400)
-		if err != nil {
-			return err
-		}
-		i.A1 = ssz.ExtendUint8(i.A1, num)
-		for ii := 0; ii < num; ii++ {
-			i.A1[ii] = ssz.UnmarshallUint8(buf[ii*1 : (ii+1)*1])
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&i.A1, tail[o4:o5], 1, 400, func(ii int, buf []byte) (err error) {
+		i.A1[ii] = ssz.UnmarshallUint8(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (5) 'A2'
-	{
-		buf = tail[o5:o6]
-		num, err := ssz.DivideInt2(len(buf), 2, 400)
-		if err != nil {
-			return err
-		}
-		i.A2 = ssz.ExtendUint16(i.A2, num)
-		for ii := 0; ii < num; ii++ {
-			i.A2[ii] = ssz.UnmarshallUint16(buf[ii*2 : (ii+1)*2])
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&i.A2, tail[o5:o6], 2, 400, func(ii int, buf []byte) (err error) {
+		i.A2[ii] = ssz.UnmarshallUint16(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (6) 'A3'
-	{
-		buf = tail[o6:o7]
-		num, err := ssz.DivideInt2(len(buf), 4, 400)
-		if err != nil {
-			return err
-		}
-		i.A3 = ssz.ExtendUint32(i.A3, num)
-		for ii := 0; ii < num; ii++ {
-			i.A3[ii] = ssz.UnmarshallUint32(buf[ii*4 : (ii+1)*4])
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&i.A3, tail[o6:o7], 4, 400, func(ii int, buf []byte) (err error) {
+		i.A3[ii] = ssz.UnmarshallUint32(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// Field (7) 'A4'
-	{
-		buf = tail[o7:]
-		num, err := ssz.DivideInt2(len(buf), 8, 400)
-		if err != nil {
-			return err
-		}
-		i.A4 = ssz.ExtendUint64(i.A4, num)
-		for ii := 0; ii < num; ii++ {
-			i.A4[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&i.A4, tail[o7:], 8, 400, func(ii int, buf []byte) (err error) {
+		i.A4[ii] = ssz.UnmarshallUint64(buf)
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/testcases/issue_127_encoding.go
+++ b/sszgen/testcases/issue_127_encoding.go
@@ -61,24 +61,15 @@ func (o *Obj2) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'T1'
-	{
-		buf = tail[o0:]
-		num, err := ssz.DecodeDynamicLength(buf, 1024)
-		if err != nil {
+	if err = ssz.UnmarshalDynamicSliceWithCallback(&o.T1, tail[o0:], 1024, func(indx int, buf []byte) (err error) {
+		if o.T1[indx], err = ssz.UnmarshalBytes(o.T1[indx], buf, 256); err != nil {
 			return err
 		}
-		o.T1 = make([]Data, num)
-		err = ssz.UnmarshalDynamic(buf, num, func(indx int, buf []byte) (err error) {
-			if len(buf) > 256 {
-				return ssz.ErrBytesLength
-			}
-			o.T1[indx] = ssz.UnmarshalBytes(o.T1[indx], buf)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/testcases/issue_156_encoding.go
+++ b/sszgen/testcases/issue_156_encoding.go
@@ -53,7 +53,7 @@ func (i *Issue156) UnmarshalSSZ(buf []byte) error {
 	copy(i.A3[:], buf[64:96])
 
 	// Field (3) 'A4'
-	i.A4 = ssz.UnmarshalBytes(i.A4, buf[96:128])
+	i.A4, _ = ssz.UnmarshalBytes(i.A4, buf[96:128])
 
 	return err
 }

--- a/sszgen/testcases/issue_166_encoding.go
+++ b/sszgen/testcases/issue_166_encoding.go
@@ -64,22 +64,15 @@ func (i *Issue165) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'A'
-	{
-		buf = tail[o0:o1]
-		if len(buf) > 0 {
-			return ssz.ErrBytesLength
-		}
-		i.A = ssz.UnmarshalBytes(i.A, buf)
+	if i.A, err = ssz.UnmarshalBytes(i.A, tail[o0:o1], 0); err != nil {
+		return err
 	}
 
 	// Field (1) 'B'
-	{
-		buf = tail[o1:]
-		if len(buf) > 0 {
-			return ssz.ErrBytesLength
-		}
-		i.B = ssz.UnmarshalBytes(i.B, buf)
+	if i.B, err = ssz.UnmarshalBytes(i.B, tail[o1:], 0); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/testcases/issue_188_encoding.go
+++ b/sszgen/testcases/issue_188_encoding.go
@@ -42,10 +42,10 @@ func (i *Issue188) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Name'
-	i.Name = ssz.UnmarshalBytes(i.Name, buf[0:32])
+	i.Name, _ = ssz.UnmarshalBytes(i.Name, buf[0:32])
 
 	// Field (1) 'Address'
-	i.Address = ssz.UnmarshalBytes(i.Address, buf[32:64])
+	i.Address, _ = ssz.UnmarshalBytes(i.Address, buf[32:64])
 
 	return err
 }

--- a/sszgen/testcases/list_encoding.go
+++ b/sszgen/testcases/list_encoding.go
@@ -35,7 +35,7 @@ func (b *BytesWrapper) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Bytes'
-	b.Bytes = ssz.UnmarshalBytes(b.Bytes, buf[0:48])
+	b.Bytes, _ = ssz.UnmarshalBytes(b.Bytes, buf[0:48])
 
 	return err
 }
@@ -116,19 +116,10 @@ func (l *ListC) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Elems'
-	{
-		buf = tail[o0:]
-		num, err := ssz.DivideInt2(len(buf), 48, 32)
-		if err != nil {
-			return err
-		}
-		l.Elems = make([]BytesWrapper, num)
-		for ii := 0; ii < num; ii++ {
-			if err := l.Elems[ii].UnmarshalSSZ(buf[ii*48 : (ii+1)*48]); err != nil {
-				return err
-			}
-		}
+	if err = ssz.UnmarshalSliceSSZ(&l.Elems, tail[o0:], 48, 32); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -221,19 +212,10 @@ func (l *ListP) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Elems'
-	{
-		buf = tail[o0:]
-		num, err := ssz.DivideInt2(len(buf), 48, 32)
-		if err != nil {
-			return err
-		}
-		l.Elems = make([]*BytesWrapper, num)
-		for ii := 0; ii < num; ii++ {
-			if err := ssz.UnmarshalField(&l.Elems[ii], buf[ii*48:(ii+1)*48]); err != nil {
-				return err
-			}
-		}
+	if err = ssz.UnmarshalSliceSSZ(&l.Elems, tail[o0:], 48, 32); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/sszgen/testcases/list_encoding.go
+++ b/sszgen/testcases/list_encoding.go
@@ -116,7 +116,12 @@ func (l *ListC) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Elems'
-	if err = ssz.UnmarshalSliceSSZ(&l.Elems, tail[o0:], 48, 32); err != nil {
+	if err = ssz.UnmarshalSliceWithIndexCallback(&l.Elems, tail[o0:], 48, 32, func(ii int, buf []byte) (err error) {
+		if err := l.Elems[ii].UnmarshalSSZ(buf); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
 

--- a/sszgen/testcases/pr_152_encoding.go
+++ b/sszgen/testcases/pr_152_encoding.go
@@ -50,17 +50,13 @@ func (p *PR1512) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'D'
-	{
-		buf = tail[o0:]
-		num, err := ssz.DivideInt2(len(buf), 48, 32)
-		if err != nil {
-			return err
-		}
-		p.D = make([]Data152, num)
-		for ii := 0; ii < num; ii++ {
-			copy(p.D[ii][:], buf[ii*48:(ii+1)*48])
-		}
+	if err = ssz.UnmarshalSliceWithIndexCallback(&p.D, tail[o0:], 48, 32, func(ii int, buf []byte) (err error) {
+		copy(p.D[ii][:], buf)
+		return nil
+	}); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/tests/codetrie_encoding.go
+++ b/tests/codetrie_encoding.go
@@ -44,7 +44,7 @@ func (m *Metadata) UnmarshalSSZ(buf []byte) error {
 	m.Version = ssz.UnmarshallUint8(buf[0:1])
 
 	// Field (1) 'CodeHash'
-	m.CodeHash = ssz.UnmarshalBytes(m.CodeHash, buf[1:33])
+	m.CodeHash, _ = ssz.UnmarshalBytes(m.CodeHash, buf[1:33])
 
 	// Field (2) 'CodeLength'
 	m.CodeLength = ssz.UnmarshallUint16(buf[33:35])
@@ -123,7 +123,7 @@ func (c *Chunk) UnmarshalSSZ(buf []byte) error {
 	c.FIO = ssz.UnmarshallUint8(buf[0:1])
 
 	// Field (1) 'Code'
-	c.Code = ssz.UnmarshalBytes(c.Code, buf[1:33])
+	c.Code, _ = ssz.UnmarshalBytes(c.Code, buf[1:33])
 
 	return err
 }
@@ -220,18 +220,10 @@ func (c *CodeTrieSmall) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (1) 'Chunks'
-	{
-		buf = tail[o1:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&c.Chunks, buf, 33, 4, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&c.Chunks[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&c.Chunks, tail[o1:], 33, 4); err != nil {
+		return err
 	}
+
 	return err
 }
 
@@ -345,18 +337,10 @@ func (c *CodeTrieBig) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (1) 'Chunks'
-	{
-		buf = tail[o1:]
-		err = ssz.UnmarshalSliceWithIndexCallback(&c.Chunks, buf, 33, 1024, func(ii int, buf []byte) (err error) {
-			if err := ssz.UnmarshalField(&c.Chunks[ii], buf); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+	if err = ssz.UnmarshalSliceSSZ(&c.Chunks, tail[o1:], 33, 1024); err != nil {
+		return err
 	}
+
 	return err
 }
 

--- a/tests/codetrie_encoding.go
+++ b/tests/codetrie_encoding.go
@@ -222,15 +222,14 @@ func (c *CodeTrieSmall) UnmarshalSSZ(buf []byte) error {
 	// Field (1) 'Chunks'
 	{
 		buf = tail[o1:]
-		num, err := ssz.DivideInt2(len(buf), 33, 4)
-		if err != nil {
-			return err
-		}
-		c.Chunks = make([]*Chunk, num)
-		for ii := 0; ii < num; ii++ {
-			if err := ssz.UnmarshalField(&c.Chunks[ii], buf[ii*33:(ii+1)*33]); err != nil {
+		err = ssz.UnmarshalSliceWithIndexCallback(&c.Chunks, buf, 33, 4, func(ii int, buf []byte) (err error) {
+			if err := ssz.UnmarshalField(&c.Chunks[ii], buf); err != nil {
 				return err
 			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return err
@@ -348,15 +347,14 @@ func (c *CodeTrieBig) UnmarshalSSZ(buf []byte) error {
 	// Field (1) 'Chunks'
 	{
 		buf = tail[o1:]
-		num, err := ssz.DivideInt2(len(buf), 33, 1024)
-		if err != nil {
-			return err
-		}
-		c.Chunks = make([]*Chunk, num)
-		for ii := 0; ii < num; ii++ {
-			if err := ssz.UnmarshalField(&c.Chunks[ii], buf[ii*33:(ii+1)*33]); err != nil {
+		err = ssz.UnmarshalSliceWithIndexCallback(&c.Chunks, buf, 33, 1024, func(ii int, buf []byte) (err error) {
+			if err := ssz.UnmarshalField(&c.Chunks[ii], buf); err != nil {
 				return err
 			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return err


### PR DESCRIPTION
This PR removes the boilerplate that was required to unmarshal array types of dynamic size.