### PR TITLE
perf: refactor tree methods

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -198,10 +198,6 @@ func TreeFromNodes(leaves []*Node, limit int) (*Node, error) {
 		return NewEmptyNode(zeroBytes[:32]), nil
 	}
 
-	if !isPowerOfTwo(limit) {
-		return nil, errors.New("limit must be power of 2")
-	}
-
 	depth := floorLog2(limit)
 	zeroOrderHashes := getZeroOrderHashes(depth)
 

--- a/tree.go
+++ b/tree.go
@@ -195,23 +195,24 @@ func TreeFromNodes(leaves []*Node, limit int) (*Node, error) {
 	numLeaves := len(leaves)
 
 	if limit <= 0 {
-		return NewEmptyNode(make([]byte, 1024)[:32]), nil
+		return NewEmptyNode(zeroBytes[:32]), nil
+	}
+
+	if !isPowerOfTwo(limit) {
+		return nil, errors.New("limit must be power of 2")
 	}
 
 	depth := floorLog2(limit)
 	zeroOrderHashes := getZeroOrderHashes(depth)
 
-	// there are no leaves, return a zero order hash node
 	if numLeaves == 0 {
 		return NewEmptyNode(zeroOrderHashes[0]), nil
 	}
 
-	// now we know numLeaves are at least 1.
-
-	// if the max leaf limit is 1, return the one leaf we have
 	if limit == 1 {
 		return leaves[0], nil
 	}
+
 	// if the max leaf limit is 2
 	if limit == 2 {
 		// but we only have 1 leaf, add a zero order hash as the right node
@@ -222,57 +223,32 @@ func TreeFromNodes(leaves []*Node, limit int) (*Node, error) {
 		return NewNodeWithLR(leaves[0], leaves[1]), nil
 	}
 
-	if !isPowerOfTwo(limit) {
-		return nil, errors.New("number of leaves should be a power of 2")
-	}
+	// Start with the leaves as our current level
+	nodes := make([]*Node, numLeaves)
+	copy(nodes, leaves)
 
-	leavesStart := powerTwo(depth)
-	leafIndex := numLeaves - 1
+	// Work upwards from the bottom of the tree
+	for d := depth; d > 0; d-- {
+		nextLevelLen := (len(nodes) + 1) / 2
+		nextLevel := make([]*Node, nextLevelLen)
 
-	maxPotentialIndex := (leavesStart+numLeaves)*2 + 4
-	nodes := make([]*Node, maxPotentialIndex)
+		for i := 0; i < len(nodes); i += 2 {
+			left := nodes[i]
+			var right *Node
 
-	nodesStartIndex := leavesStart
-	nodesEndIndex := nodesStartIndex + numLeaves - 1
-
-	// for each tree level
-	for k := depth; k >= 0; k-- {
-		for i := nodesEndIndex; i >= nodesStartIndex; i-- {
-			// leaf node, add to map
-			if k == depth {
-				if leafIndex < 0 {
-					return nil, errors.New("invalid leaf indexing")
-				}
-				nodes[i] = leaves[leafIndex]
-				leafIndex--
-			} else { // branch node, compute
-				leftIndex := i * 2
-				rightIndex := i*2 + 1
-				// both nodes are empty, unexpected condition
-				if (leftIndex >= len(nodes) || nodes[leftIndex] == nil) && (rightIndex >= len(nodes) || nodes[rightIndex] == nil) {
-					return nil, errors.New("unexpected empty right and left nodes")
-				}
-				// node with empty right node, add zero order hash as right node and mark right node as empty
-				if leftIndex < len(nodes) && nodes[leftIndex] != nil && (rightIndex >= len(nodes) || nodes[rightIndex] == nil) {
-					nodes[i] = NewNodeWithLR(nodes[leftIndex], NewEmptyNode(zeroOrderHashes[k+1]))
-				}
-				// node with left and right child
-				if leftIndex < len(nodes) && nodes[leftIndex] != nil && rightIndex < len(nodes) && nodes[rightIndex] != nil {
-					nodes[i] = NewNodeWithLR(nodes[leftIndex], nodes[rightIndex])
-				}
+			if i+1 < len(nodes) {
+				right = nodes[i+1]
+			} else {
+				// Fill missing sibling with precomputed zero hash for this depth
+				right = NewEmptyNode(zeroOrderHashes[d])
 			}
+
+			nextLevel[i/2] = NewNodeWithLR(left, right)
 		}
-		nodesStartIndex = nodesStartIndex / 2
-		nodesEndIndex = int(math.Floor(float64(nodesEndIndex)) / 2)
+		nodes = nextLevel
 	}
 
-	rootNode := nodes[1]
-
-	if rootNode == nil {
-		return nil, errors.New("tree root node could not be computed")
-	}
-
-	return rootNode, nil
+	return nodes[0], nil
 }
 
 func TreeFromNodesWithMixin(leaves []*Node, num, limit int) (*Node, error) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -415,10 +415,7 @@ func BenchmarkTreeFromNodes(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				_, err := TreeFromNodes(bm.nodes, bm.limit)
-				if err != nil {
-					
-				}
+				TreeFromNodes(bm.nodes, bm.limit)
 			}
 		})
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -414,7 +414,7 @@ func BenchmarkTreeFromNodes(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 
-			for b.Loop() {
+			for i := 0; i < b.N; i++ {
 				TreeFromNodes(bm.nodes, bm.limit)
 			}
 		})

--- a/tree_test.go
+++ b/tree_test.go
@@ -289,3 +289,137 @@ func BenchmarkProve(b *testing.B) {
 		}
 	}
 }
+
+var TestCasesTreeFromNodes = []struct {
+	name        string
+	nodes       []*Node
+	limit       int
+	expectError bool
+	validateFn  func(*testing.T, *Node)
+}{
+	{
+		name:        "zero limit returns empty node",
+		nodes:       []*Node{},
+		limit:       0,
+		expectError: false,
+		validateFn: func(t *testing.T, n *Node) {
+			if !n.isEmpty {
+				t.Error("expected empty node for zero limit")
+			}
+		},
+	},
+	{
+		name:        "no nodes with limit",
+		nodes:       []*Node{},
+		limit:       4,
+		expectError: false,
+		validateFn: func(t *testing.T, n *Node) {
+			if !n.isEmpty {
+				t.Error("expected empty node for no leaves")
+			}
+		},
+	},
+	{
+		name:        "single node with limit 1",
+		nodes:       []*Node{NewNodeWithValue([]byte{1})},
+		limit:       1,
+		expectError: false,
+		validateFn: func(t *testing.T, n *Node) {
+			if !(n.left == nil && n.right == nil) {
+				t.Error("expected leaf node")
+			}
+		},
+	},
+	{
+		name:        "single node with limit 2",
+		nodes:       []*Node{NewNodeWithValue([]byte{1})},
+		limit:       2,
+		expectError: false,
+		validateFn: func(t *testing.T, n *Node) {
+			if n.left == nil && n.right == nil {
+				t.Error("expected branch node")
+			}
+			if n.right == nil || !n.right.isEmpty {
+				t.Error("expected empty right child")
+			}
+		},
+	},
+	{
+		name:        "two nodes with limit 2",
+		nodes:       []*Node{NewNodeWithValue([]byte{1}), NewNodeWithValue([]byte{2})},
+		limit:       2,
+		expectError: false,
+		validateFn: func(t *testing.T, n *Node) {
+			if n.left == nil && n.right == nil {
+				t.Error("expected branch node")
+			}
+		},
+	},
+	{
+		name:        "non-power of 2 limit",
+		nodes:       []*Node{NewNodeWithValue([]byte{1})},
+		limit:       3,
+		expectError: true,
+	},
+	{
+		name: "four nodes with limit 8",
+		nodes: []*Node{
+			NewNodeWithValue([]byte{1}),
+			NewNodeWithValue([]byte{2}),
+			NewNodeWithValue([]byte{3}),
+			NewNodeWithValue([]byte{4}),
+		},
+		limit:       8,
+		expectError: false,
+		validateFn: func(t *testing.T, n *Node) {
+			// Should have padding on the right side
+			if n.left == nil && n.right == nil {
+				t.Error("expected branch node")
+			}
+		},
+	},
+}
+
+func TestTreeFromNodes(t *testing.T) {
+	for _, tt := range TestCasesTreeFromNodes {
+		t.Run(tt.name, func(t *testing.T) {
+			tree, err := TreeFromNodes(tt.nodes, tt.limit)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tree == nil {
+				t.Fatal("tree should not be nil")
+			}
+
+			if tt.validateFn != nil {
+				tt.validateFn(t, tree)
+			}
+		})
+	}
+}
+
+func BenchmarkTreeFromNodes(b *testing.B) {
+	for _, bm := range TestCasesTreeFromNodes {
+		b.Run(bm.name, func(b *testing.B) {
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_, err := TreeFromNodes(bm.nodes, bm.limit)
+				if err != nil {
+					
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Optimize `Prove`  & `TreeFromNodes` Method

Benchmark `Prove`
```
goos: linux
goarch: amd64
pkg: github.com/ferranbt/fastssz
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
        │ old_bench.txt │           new_bench.txt            │
        │    sec/op     │   sec/op    vs base                │
Prove-8      3.115 ± 1%   1.583 ± 3%  -49.17% (p=0.000 n=10)

        │ old_bench.txt │            new_bench.txt             │
        │     B/op      │     B/op      vs base                │
Prove-8    829.7Mi ± 0%   605.1Mi ± 0%  -27.07% (p=0.000 n=10)

        │ old_bench.txt │           new_bench.txt            │
        │   allocs/op   │  allocs/op   vs base               │
Prove-8     8.946M ± 0%   8.913M ± 0%  -0.37% (p=0.000 n=10)
```

Benchmark `TreeFromNodes`
```
goos: linux
goarch: amd64
pkg: github.com/ferranbt/fastssz
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                                              │ new_bench.txt │             old_bench.txt              │
                                              │     sec/op     │    sec/op     vs base                  │
TreeFromNodes/zero_limit_returns_empty_node-8     34.92n ± 17%    36.12n ± 4%          ~ (p=0.105 n=10)
TreeFromNodes/no_nodes_with_limit-8               1.637µ ±  2%    1.657µ ± 4%          ~ (p=0.066 n=10)
TreeFromNodes/single_node_with_limit_1-8          2.109n ±  4%   66.175n ± 7%  +3038.49% (p=0.000 n=10)
TreeFromNodes/single_node_with_limit_2-8          918.0n ± 12%    921.2n ± 1%          ~ (p=0.927 n=10)
TreeFromNodes/two_nodes_with_limit_2-8            887.3n ±  3%    875.0n ± 5%          ~ (p=0.631 n=10)
TreeFromNodes/non-power_of_2_limit-8              26.01n ±  5%   887.55n ± 3%  +3312.34% (p=0.000 n=10)
TreeFromNodes/four_nodes_with_limit_8-8           2.598µ ±  2%    2.876µ ± 3%    +10.72% (p=0.000 n=10)
geomean                                           182.1n          503.0n        +176.26%

                                              │ new_bench.txt │              old_bench.txt              │
                                              │      B/op      │    B/op      vs base                    │
TreeFromNodes/zero_limit_returns_empty_node-8     48.00 ± 0%      48.00 ± 0%          ~ (p=1.000 n=10) ¹
TreeFromNodes/no_nodes_with_limit-8               352.0 ± 0%      352.0 ± 0%          ~ (p=1.000 n=10) ¹
TreeFromNodes/single_node_with_limit_1-8           0.00 ± 0%      56.00 ± 0%          ? (p=0.000 n=10)
TreeFromNodes/single_node_with_limit_2-8          272.0 ± 0%      272.0 ± 0%          ~ (p=1.000 n=10) ¹
TreeFromNodes/two_nodes_with_limit_2-8            224.0 ± 0%      224.0 ± 0%          ~ (p=1.000 n=10) ¹
TreeFromNodes/non-power_of_2_limit-8              16.00 ± 0%     192.00 ± 0%  +1100.00% (p=0.000 n=10)
TreeFromNodes/four_nodes_with_limit_8-8           672.0 ± 0%      656.0 ± 0%     -2.38% (p=0.000 n=10)
geomean                                                      ²    184.4       ?
¹ all samples are equal
² summaries must be >0 to compute geomean

                                              │ new_bench.txt │             old_bench.txt             │
                                              │   allocs/op    │ allocs/op   vs base                   │
TreeFromNodes/zero_limit_returns_empty_node-8     1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=10) ¹
TreeFromNodes/no_nodes_with_limit-8               7.000 ± 0%     7.000 ± 0%         ~ (p=1.000 n=10) ¹
TreeFromNodes/single_node_with_limit_1-8          0.000 ± 0%     2.000 ± 0%         ? (p=0.000 n=10)
TreeFromNodes/single_node_with_limit_2-8          6.000 ± 0%     6.000 ± 0%         ~ (p=1.000 n=10) ¹
TreeFromNodes/two_nodes_with_limit_2-8            5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=10) ¹
TreeFromNodes/non-power_of_2_limit-8              1.000 ± 0%     5.000 ± 0%  +400.00% (p=0.000 n=10)
TreeFromNodes/four_nodes_with_limit_8-8           14.00 ± 0%     13.00 ± 0%    -7.14% (p=0.000 n=10)
geomean                                                      ²   4.303       ?
¹ all samples are equal
² summaries must be >0 to compute geomean
```